### PR TITLE
Add trackhubs skill — UCSC Track Hub / Assembly Hub publishing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,7 @@ Place your skill in the appropriate category:
 | `nf-to-galaxy/` | Nextflow → Galaxy conversion | process-to-tool, workflow conversion |
 | `galaxy-integration/` | Galaxy instance integration (MCP, BioBlend) | tool-checking, workflow-testing |
 | `collection-manipulation/` | Galaxy collection transformations | filter, sort, restructure, Apply Rules |
+| `trackhubs/` | UCSC Track Hub / Assembly Hub publishing | bigChain conversion, composite-track rules, hub.txt/genomes.txt/trackDb.txt, hubCheck |
 
 ---
 

--- a/trackhubs/README.md
+++ b/trackhubs/README.md
@@ -1,0 +1,33 @@
+# trackhubs
+
+UCSC Track Hub and Assembly Hub building skills. See [SKILL.md](SKILL.md) for the entry point.
+
+## Why this skill exists
+
+UCSC Track Hubs are a common publishing target for comparative-genomics outputs from Galaxy: pangenome graphs, multiz alignments, pairwise chains, gene annotations, selection scans, and cohort VCFs all surface naturally as hub tracks. The schema is well-documented but has several traps that an LLM consistently falls into without guardrails:
+
+- Inventing `type chain` (not a real track-hub type) instead of `bigChain`
+- Pointing tracks at gzipped text files instead of indexed binaries
+- Putting `bigMaf` and `bigChain` in the same composite (composites must be single-type)
+- Emitting `genomes.txt` with empty `defaultPos` (silent failure)
+- Missing companion files (`.bb.bai`, `.bigChain.link.bb`, `.tbi` instead of `.csi`)
+
+Each of those errors was caught only by review of a real PR (galaxyproject/brc-analytics#1279), not by `hubCheck -level=warn`. This skill encodes the lessons so the next workflow gets them right the first time.
+
+## Skill structure
+
+- **[SKILL.md](SKILL.md)** — main entry point. Quick reference, workflow, common pitfalls.
+- **[references/composite-tracks.md](references/composite-tracks.md)** — single-type rule, superTrack vs. compositeTrack vs. multiWig
+- **[references/chain-to-bigchain.md](references/chain-to-bigchain.md)** — full chain → bigChain conversion script + recipe
+- **[references/genomes-txt-fields.md](references/genomes-txt-fields.md)** — every field of `genomes.txt`, assembly-hub vs. track-hub, validation pitfalls
+- **[references/hubcheck-debugging.md](references/hubcheck-debugging.md)** — `hubCheck` error and warning catalog
+
+## See also
+
+- [Galaxy `ucsc-kent-tools` wrappers](https://github.com/galaxyproject/tools-iuc/tree/main/tools/ucsc-tools) — most kent utilities are already wrapped; this skill calls out the gaps
+- UCSC official docs:
+  - <https://genome.ucsc.edu/goldenPath/help/hgTrackHubHelp.html>
+  - <https://genome.ucsc.edu/goldenPath/help/hubQuickStartAssembly.html>
+  - <https://genome.ucsc.edu/goldenPath/help/bigChain.html>
+  - <https://genome.ucsc.edu/goldenPath/help/bigMaf.html>
+  - <https://genome.ucsc.edu/goldenPath/help/trackDb/trackDbHub.html> — the full trackDb field reference

--- a/trackhubs/SKILL.md
+++ b/trackhubs/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: trackhubs
+description: Building UCSC Track Hubs (track hubs and assembly hubs) — bigBed/bigChain/bigMaf format requirements, composite-track rules, hub.txt / genomes.txt / trackDb.txt structure. Use when emitting a UCSC hub from Galaxy outputs, wrapping a hub-publishing tool, or debugging hubCheck failures.
+---
+
+# UCSC Track Hubs
+
+Reference for building UCSC Track Hubs and Assembly Hubs from Galaxy outputs. Catches the recurring class of LLM errors where the wrong track type is emitted, composites mix incompatible types, or `genomes.txt` ships with empty `defaultPos`.
+
+## When to Use
+
+- Emitting a UCSC hub bundle (`hub.txt` + `genomes.txt` + per-assembly `trackDb.txt`) from any Galaxy workflow
+- Writing a Galaxy tool that produces big-format files (`bigBed`, `bigMaf`, `bigChain`, `bigWig`, `vcfTabix`) destined for a hub
+- Debugging `hubCheck` failures
+- Reviewing AI-generated `trackDb.txt` / `genomes.txt`
+
+## The four errors that catch every first attempt
+
+| Mistake | What breaks | Fix |
+|---|---|---|
+| `type chain` with a `.chain.gz` file | Hub silently fails to load chain tracks | Use `type bigChain` with `bigChain.bb` + `linkDataUrl` to `bigChain.link.bb`. See `references/chain-to-bigchain.md` |
+| Mixing `bigMaf` + `bigChain` in one composite | `hubCheck` fails: "type mismatch in compositeTrack" | One composite per `type`. See `references/composite-tracks.md` |
+| Empty `defaultPos` in `genomes.txt` | Hub loads but the browser jumps nowhere; users see "no data" | `defaultPos chrN:start-end` must be a real region |
+| Missing `.2bit` for an assembly hub | Hub fails to render the assembly's chromosomes | Build with `faToTwoBit` and point `twoBitPath` at the file (relative to `genomes.txt`) |
+
+All four are documented with concrete fixes in the references below.
+
+## Quick reference — track type → file format
+
+| Track type    | File format       | Schema (`-as=`) | Companion files       |
+|---------------|-------------------|-----------------|-----------------------|
+| `bigMaf`      | `.bb` (bigBed 3+1)| `bigMaf.as`     | optional `.bb.bai` index for fast range queries |
+| `bigChain`    | `.bb` (bigBed 6+6)| `bigChain.as`   | **required**: `.bigChain.link.bb` (bigBed 4+1, `bigLink.as`) referenced via `linkDataUrl` |
+| `bigBed`      | `.bb` (bigBed N)  | optional        | none                  |
+| `bigBed 12 +` | `.bb` (bigBed 12+N)| custom `.as` schema for the `+N` fields | none |
+| `bigWig`      | `.bw`             | none            | none                  |
+| `vcfTabix`    | `.vcf.gz`         | none            | **required**: `.tbi` (UCSC needs Tabix `.tbi`, not BCFtools default `.csi`) |
+| `bam`         | `.bam`            | none            | **required**: `.bai`  |
+
+**Always**: every binary file needs its index/companion. Hub will load but the track will be silently missing if a companion is absent.
+
+## hub.txt / genomes.txt / trackDb.txt — full structure
+
+```
+hub-root/
+├── hub.txt            ← describes the whole hub (one file)
+├── genomes.txt        ← lists every assembly (one record per assembly)
+└── {ACC}/             ← per-assembly directory
+    ├── trackDb.txt    ← tracks for this assembly
+    ├── groups.txt     ← OPTIONAL track-group ordering
+    ├── {ACC}.2bit     ← REQUIRED for assembly hubs (custom genomes)
+    ├── description.html  ← OPTIONAL assembly description
+    └── …big files referenced by trackDb.txt
+```
+
+A bare-minimum `hub.txt`:
+
+```
+hub MyHub
+shortLabel My hub
+longLabel  Full descriptive label of the hub
+genomesFile genomes.txt
+email me@example.org
+```
+
+A bare-minimum `genomes.txt` record for an **assembly hub** (custom genome not in UCSC's databases):
+
+```
+genome GCA_900093555.2
+trackDb GCA_900093555.2/trackDb.txt
+groups GCA_900093555.2/groups.txt
+description Plasmodium vivax PvP01 (GCA_900093555.2)
+twoBitPath GCA_900093555.2/GCA_900093555.2.2bit
+organism Plasmodium_vivax
+defaultPos LT635625.2:1264700-1277700
+scientificName Plasmodium vivax
+htmlPath GCA_900093555.2/description.html
+```
+
+For a **track hub** on an already-supported UCSC assembly (e.g. `hg38`, `mm10`), drop `twoBitPath` and `htmlPath` and use the UCSC assembly name as `genome`. The other fields stay.
+
+A `trackDb.txt` with one standalone track + one composite:
+
+```
+track multiz
+shortLabel multiz
+longLabel  8-way multi-z alignment
+type bigMaf
+bigDataUrl multiz.bb
+visibility pack
+speciesOrder strain1 strain2 strain3 …
+
+track chains_composite
+compositeTrack on
+shortLabel Pairwise chains
+longLabel  Pairwise chain alignments to other assemblies
+type bigChain
+visibility hide
+
+    track chain_to_GCA_X
+    parent chains_composite off
+    shortLabel chain to GCA_X
+    longLabel  Chain alignment to GCA_X
+    type bigChain GCA_X        ← second word = target assembly
+    bigDataUrl chains/this_to_X.bigChain.bb
+    linkDataUrl chains/this_to_X.bigChain.link.bb
+    visibility hide
+```
+
+## Workflow — emitting a hub from a Galaxy workflow
+
+1. **Per-assembly files first**. For each assembly the hub will carry:
+   - Build the `.2bit` via `faToTwoBit` (if it's an assembly hub).
+   - Convert every binary input to its big-format with the right `bedToBigBed -as=…` / `mafToBigMaf` / `bgzip` + `tabix` pipeline.
+   - Make sure every companion (`.bb.bai`, `.link.bb`, `.tbi`) is built and named exactly as the trackDb will reference it.
+2. **Emit `trackDb.txt` per assembly** with a generator (Python is fine). Group tracks into composites by **single `type`**. bigMaf and bigChain go in separate top-level tracks. See `references/composite-tracks.md`.
+3. **Emit `genomes.txt`** with the 9 required fields. `defaultPos` must be a real region on a real contig. `twoBitPath` must resolve (relative to `genomes.txt`).
+4. **Emit `hub.txt`**. Validate with `hubCheck -level=warn file://$WORK/hub.txt`. Fix every warning before publishing.
+5. **Publish**: `rsync` to the hub server, or stage to a public bucket (S3, Dropbox-with-direct-link, etc.) referenced by the catalog.
+
+Galaxy collection trick: the hub layout requires per-assembly directories. Galaxy can encode this via `list:list` collections (outer = assembly, inner = track type). The `build_trackdb` wrapper should accept the outer collection name as the assembly accession.
+
+## Common Pitfalls
+
+### bigMaf and bigChain cannot share a composite
+
+```xml
+<!-- WRONG: hubCheck error "type mismatch in compositeTrack" -->
+track multi_align
+compositeTrack on
+type bed                  ← bogus placeholder
+    track maf_track
+    type bigMaf
+    bigDataUrl x.maf.bb
+    track chain_track
+    type bigChain
+    bigDataUrl y.chain.bb
+```
+
+```xml
+<!-- CORRECT: standalone bigMaf + separate bigChain composite -->
+track multiz
+type bigMaf
+bigDataUrl x.maf.bb
+
+track chains
+compositeTrack on
+type bigChain
+    track chain_a
+    parent chains off
+    type bigChain GCA_xxx
+    bigDataUrl y.chain.bb
+    linkDataUrl y.chain.link.bb
+```
+
+UCSC's composite-track rule: **all sub-tracks share one `type`.** Multi-type bundling needs `superTrack on` (which only groups visually) or `multiWig` (bigWig-only).
+
+### bigChain needs both `.bb` and `.link.bb`
+
+A bigChain track references **two** files. The data file (`bigDataUrl`, bigBed 6+6 from `bigChain.as`) carries the chain headers; the link file (`linkDataUrl`, bigBed 4+1 from `bigLink.as`) carries the block-by-block alignment positions. Without the link file the track loads but draws nothing.
+
+See `references/chain-to-bigchain.md` for the awk/Python recipe.
+
+### `defaultPos` must be a real contig:start-end
+
+```
+defaultPos                                          ← WRONG, empty
+defaultPos chr1                                     ← WRONG, no range
+defaultPos chr1:1                                   ← WRONG, no end
+defaultPos chr1:1-200000                            ← OK
+defaultPos LT635625.2:1264700-1277700               ← OK (assembly-hub style)
+```
+
+For an assembly hub, the contig name must match a name in the `.2bit`. The `twoBitInfo` tool will dump contig names if you forget them.
+
+### vcfTabix needs `.tbi`, not `.csi`
+
+`bcftools index` defaults to `.csi`. UCSC's `vcfTabix` only reads Tabix `.tbi`. Re-index with `bcftools index -t` or `tabix -p vcf`.
+
+## See Also
+
+- `references/composite-tracks.md` — the single-type rule and supertrack / multiWig alternatives
+- `references/chain-to-bigchain.md` — concrete chain → bigChain conversion script
+- `references/genomes-txt-fields.md` — every field of `genomes.txt` with required-vs-optional and worked examples
+- `references/hubcheck-debugging.md` — common `hubCheck` errors and their fixes
+- Galaxy `ucsc-kent-tools` wrappers (iuc) — most kent utilities are already wrapped; missing pieces flagged in `tool-dev` skill
+- UCSC official docs:
+  - <https://genome.ucsc.edu/goldenPath/help/hgTrackHubHelp.html> — Track Hub guide
+  - <https://genome.ucsc.edu/goldenPath/help/hubQuickStartAssembly.html> — Assembly Hub quickstart
+  - <https://genome.ucsc.edu/goldenPath/help/bigChain.html> — bigChain conversion recipe
+  - <https://genome.ucsc.edu/goldenPath/help/bigMaf.html> — bigMaf conversion recipe

--- a/trackhubs/references/chain-to-bigchain.md
+++ b/trackhubs/references/chain-to-bigchain.md
@@ -1,0 +1,169 @@
+# Chain → bigChain conversion
+
+UCSC track hubs accept pairwise chain alignments only as the `bigChain` track type, which reads two indexed binary bigBed files. A `.chain.gz` text file as `bigDataUrl` will not load. Build both files with one pass over the chain.
+
+## What you produce
+
+For every input `pair.chain` (or `pair.chain.gz`):
+
+| Output | Format | Schema (`-as=`) | Hub reference |
+|---|---|---|---|
+| `pair.bigChain.bb` | bigBed 6+6 | `bigChain.as` | `bigDataUrl` |
+| `pair.bigChain.link.bb` | bigBed 4+1 | `bigLink.as` | `linkDataUrl` |
+
+Both files are needed. Without the link file the track loads but draws nothing.
+
+## Schema files
+
+`bigChain.as`:
+
+```
+table bigChain
+"bigChain pairAlignment"
+    (
+    string  chrom;         "Reference sequence chromosome or scaffold"
+    uint    chromStart;    "Start position in chromosome"
+    uint    chromEnd;      "End position in chromosome"
+    string  name;          "Chain id (numeric, unique within file)"
+    uint    score;         "Display score (use 1000)"
+    char[1] strand;        "+ or - for query strand"
+    uint    tSize;         "Target sequence length"
+    string  qName;         "Query sequence name"
+    uint    qSize;         "Query sequence length"
+    uint    qStart;        "Start of alignment on query"
+    uint    qEnd;          "End of alignment on query"
+    uint    chainScore;    "Score from the chain header"
+    )
+```
+
+`bigLink.as`:
+
+```
+table bigLink
+"bigLink pairwise alignment"
+    (
+    string  chrom;         "Reference sequence chromosome or scaffold"
+    uint    chromStart;    "Start position in chromosome"
+    uint    chromEnd;      "End position in chromosome"
+    string  name;          "Chain id (matches chain in bigChain)"
+    uint    qStart;        "Start in query"
+    )
+```
+
+## The pass — Python
+
+The UCSC chain format alternates one header line per chain plus a sequence of block lines (`size dt dq`, last line of each chain block has only `size`):
+
+```
+chain SCORE tName tSize tStrand tStart tEnd qName qSize qStrand qStart qEnd id
+size dt dq
+size dt dq
+…
+size
+(blank line)
+chain …
+```
+
+`hgLoadChain -noBin -test …` in kentUtils does this conversion natively but is not always available. The script below produces equivalent output in one pass:
+
+```python
+#!/usr/bin/env python3
+"""Convert UCSC chain (gz or plain) to bigChain.bed + bigLink.bed."""
+import gzip, sys
+from pathlib import Path
+
+def open_text(p):
+    p = Path(p)
+    return gzip.open(p, "rt") if p.suffix == ".gz" else open(p)
+
+def convert(chain_path, big_bed, big_link):
+    with open_text(chain_path) as fh, open(big_bed, "w") as out_bed, open(big_link, "w") as out_link:
+        skip = False
+        for line in fh:
+            line = line.rstrip()
+            if not line:
+                continue
+            if line.startswith("chain "):
+                p = line.split()
+                score, tName, tSize, tStrand = int(p[1]), p[2], int(p[3]), p[4]
+                tStart, tEnd = int(p[5]), int(p[6])
+                qName, qSize, qStrand = p[7], int(p[8]), p[9]
+                qStart, qEnd, chain_id = int(p[10]), int(p[11]), p[12]
+                if tStrand != "+":
+                    sys.stderr.write(f"skip chain {chain_id}: tStrand={tStrand}\n")
+                    skip = True
+                    continue
+                skip = False
+                out_bed.write("\t".join(map(str, [
+                    tName, tStart, tEnd, chain_id, 1000, qStrand,
+                    tSize, qName, qSize, qStart, qEnd, score
+                ])) + "\n")
+                t_cur, q_cur = tStart, qStart
+            else:
+                if skip:
+                    continue
+                p = line.split()
+                if len(p) == 3:
+                    size, dt, dq = int(p[0]), int(p[1]), int(p[2])
+                elif len(p) == 1:
+                    size, dt, dq = int(p[0]), 0, 0
+                else:
+                    continue
+                out_link.write("\t".join(map(str, [
+                    tName, t_cur, t_cur + size, chain_id, q_cur
+                ])) + "\n")
+                t_cur += size + dt
+                q_cur += size + dq
+
+if __name__ == "__main__":
+    convert(*sys.argv[1:])
+```
+
+## End-to-end recipe
+
+```bash
+# 1. Convert chain to two bed files
+python3 chain_to_bigChain.py pair.chain.gz pair.bigChain.bed.raw pair.bigLink.bed.raw
+
+# 2. Sort (bedToBigBed requires sorted input)
+sort -k1,1 -k2,2n pair.bigChain.bed.raw > pair.bigChain.bed
+sort -k1,1 -k2,2n pair.bigLink.bed.raw  > pair.bigLink.bed
+
+# 3. Build bigBeds against the TARGET assembly's .sizes
+bedToBigBed -type=bed6+6 -as=bigChain.as -tab pair.bigChain.bed target.sizes pair.bigChain.bb
+bedToBigBed -type=bed4+1 -as=bigLink.as  -tab pair.bigLink.bed  target.sizes pair.bigChain.link.bb
+```
+
+Run-time: ~5 s per chain pair on one CPU; an 8-strain × 7-target panel (56 pairs) finishes in ~5 min.
+
+## trackDb stanza
+
+```
+track chain_to_A
+parent chains_composite off
+shortLabel chain to A
+longLabel  Chain alignment from this assembly to A
+type bigChain GCA_A                          ← second word is the target assembly in genomes.txt
+bigDataUrl chains/this_to_A.bigChain.bb       ← bigBed 6+6
+linkDataUrl chains/this_to_A.bigChain.link.bb ← bigBed 4+1
+visibility hide
+```
+
+Both `bigDataUrl` and `linkDataUrl` are required.
+
+## Galaxy wrapping notes
+
+For a Galaxy tool wrapper:
+
+- Inputs: chain file (`.chain.gz` or `.chain`), target `.sizes`, optionally the target assembly name (for the `type bigChain {ASSEMBLY}` line in the generated `trackDb.txt` stanza).
+- Outputs: paired `.bigChain.bb` + `.bigChain.link.bb`. Use a `list:paired` collection so downstream `build_trackdb` can map over assembly pairs.
+- Datatype: declare the outputs as `bigbed` (Galaxy doesn't have a `bigChain` datatype yet; `bigbed` is the closest match).
+
+## Common conversion bugs
+
+| Bug | Fix |
+|---|---|
+| `bedToBigBed` errors with "out of order" | forgot `sort -k1,1 -k2,2n` |
+| `bedToBigBed` errors with "chromosome not in .sizes" | wrong `.sizes` (you used source instead of target) |
+| `chain` lines with `tStrand=-` | rare but possible; either swap orientations upstream (`chainSwap` from kentUtils) or skip those chains as shown in the script |
+| Empty `bigChain.bb` | chain file was empty after PAF→chain step; check the upstream `axtChain`/`paftools.js view -f chain` step |

--- a/trackhubs/references/composite-tracks.md
+++ b/trackhubs/references/composite-tracks.md
@@ -1,0 +1,110 @@
+# Composite tracks — the single-type rule
+
+UCSC composite tracks bundle related sub-tracks under one control panel. They have one hard rule that every first-time hub author trips over:
+
+> **All sub-tracks of a composite must share the same `type`.**
+
+A composite with `type bigMaf` accepts only `bigMaf` sub-tracks. A composite with `type bigChain` accepts only `bigChain` sub-tracks. Mixing types makes `hubCheck` emit "type mismatch in compositeTrack" and silently drops the offending sub-tracks at render time.
+
+## Decision: composite vs. superTrack vs. multiWig
+
+| Container | Sub-track types | When to use |
+|---|---|---|
+| `compositeTrack on` | single `type` | grouping N tracks of the same kind (e.g. one chain per pairwise comparison) |
+| `superTrack on` | any mix | visually grouping unrelated tracks in the browser UI; no shared settings |
+| `multiWig on` | bigWig only | overlaying multiple bigWigs in one panel |
+
+Most "I want everything under one heading" cases are actually `superTrack`. Composite is the right answer only when the sub-tracks really do share a `type`.
+
+## Worked examples
+
+### One standalone + two composites (the common shape)
+
+```
+# Standalone bigMaf (one big alignment, no siblings)
+track multiz
+shortLabel multiz
+longLabel  8-way multi-z alignment
+type bigMaf
+bigDataUrl multiz.bb
+visibility pack
+
+# Composite of bigChain — one per pairwise comparison
+track chains_composite
+compositeTrack on
+shortLabel Chains
+longLabel  Pairwise chain alignments
+type bigChain
+visibility hide
+
+    track chain_to_A
+    parent chains_composite off
+    type bigChain GCA_A
+    bigDataUrl chains/this_to_A.bigChain.bb
+    linkDataUrl chains/this_to_A.bigChain.link.bb
+
+    track chain_to_B
+    parent chains_composite off
+    type bigChain GCA_B
+    bigDataUrl chains/this_to_B.bigChain.bb
+    linkDataUrl chains/this_to_B.bigChain.link.bb
+
+# Composite of bigBed 12 — gene projections from N anchors
+track annot_composite
+compositeTrack on
+shortLabel Gene projections
+longLabel  Cross-strain gene projections
+type bigBed 12
+visibility dense
+
+    track annot_from_A
+    parent annot_composite on
+    type bigBed 12
+    bigDataUrl annot_from_A.bb
+
+    track annot_from_B
+    parent annot_composite off
+    type bigBed 12
+    bigDataUrl annot_from_B.bb
+```
+
+### `superTrack` for grouping unrelated track types
+
+```
+track all_pangenome
+superTrack on show
+shortLabel Pangenome
+longLabel  Everything pangenome on this assembly
+
+    track multiz
+    parent all_pangenome
+    type bigMaf
+    bigDataUrl multiz.bb
+
+    track chains_composite
+    parent all_pangenome
+    compositeTrack on
+    type bigChain
+        track chain_to_A
+        parent chains_composite off
+        type bigChain GCA_A
+        bigDataUrl chains/this_to_A.bigChain.bb
+        linkDataUrl chains/this_to_A.bigChain.link.bb
+```
+
+Note the nesting: `superTrack` holds the standalone bigMaf and the bigChain composite as siblings; the composite's own sub-tracks live one level deeper. The composite still has to be single-type internally — `superTrack` only relaxes the rule at the outer level.
+
+## Errors hubCheck emits
+
+| Error | Real meaning |
+|---|---|
+| `type mismatch in compositeTrack` | one of your sub-tracks declares a different `type` than the composite's parent `type` |
+| `parent track not found` | you set `parent X` on a sub-track but no track named `X` exists, or it isn't a composite/superTrack |
+| `compositeTrack lines must come before sub-tracks` | indent or order issue — composite header must precede its members |
+| `unknown track type` | `type X` is not a UCSC-supported type. Common typo: `chain` (use `bigChain`), `maf` (use `bigMaf`) |
+
+## Tips for AI-generated trackDb.txt
+
+- Generate one container per track-type bucket. If the bucket has one member, emit it standalone (no composite wrapper). If the bucket has many, wrap in composite.
+- Verify every `type` matches its sub-track's actual file extension and schema. Don't assume `type bed` is a safe placeholder — it isn't; pick the actual type.
+- For composite parents, set the second `type` argument (e.g. `type bigChain GCA_xxx`) **only on sub-tracks**, not on the composite parent. The parent's `type bigChain` (no second word) is correct.

--- a/trackhubs/references/genomes-txt-fields.md
+++ b/trackhubs/references/genomes-txt-fields.md
@@ -1,0 +1,72 @@
+# `genomes.txt` field reference
+
+One record per assembly, separated by a blank line. Required fields differ between **assembly hubs** (custom genome, you ship the `.2bit`) and **track hubs** (genome already in UCSC's databases, you just add tracks).
+
+## Required fields — Assembly Hub
+
+| Field | Required | Notes |
+|---|---|---|
+| `genome` | yes | Assembly identifier — usually the GenBank accession (`GCA_xxx`). Used as the directory name for per-assembly files. |
+| `trackDb` | yes | Relative path to `trackDb.txt`. Convention: `{genome}/trackDb.txt`. |
+| `groups` | yes | Relative path to `groups.txt`. Convention: `{genome}/groups.txt`. |
+| `description` | yes | Human-readable description shown in the genome chooser. |
+| `twoBitPath` | yes | Relative path to the assembly's `.2bit`. Build with `faToTwoBit input.fa output.2bit`. |
+| `organism` | yes | Common name with underscores for spaces: `Plasmodium_vivax`. |
+| `defaultPos` | yes | **Real** `chrN:start-end` — must point at a contig in the `.2bit`. Empty value = hub fails to render. |
+| `scientificName` | yes | Two-word binomial: `Plasmodium vivax`. |
+| `htmlPath` | recommended | Relative path to an HTML description file shown when the assembly is selected. |
+| `orderKey` | optional | Integer for sort order in the chooser. Lower = earlier. |
+
+## Required fields — Track Hub
+
+For a known UCSC assembly (e.g. `hg38`, `mm10`, `dm6`):
+
+| Field | Required | Notes |
+|---|---|---|
+| `genome` | yes | Must match a UCSC assembly name **exactly** (case-sensitive). Wrong: `hg38` for an assembly UCSC calls `GRCh38`. Check with `curl -s https://api.genome.ucsc.edu/list/ucscGenomes \| jq …` if unsure. |
+| `trackDb` | yes | Relative path. |
+| All other fields | not needed | `twoBitPath`, `defaultPos`, etc. come from UCSC's existing assembly metadata. |
+
+## Examples
+
+### Assembly Hub record
+
+```
+genome GCA_900093555.2
+trackDb GCA_900093555.2/trackDb.txt
+groups GCA_900093555.2/groups.txt
+description Plasmodium vivax PvP01 (GCA_900093555.2)
+twoBitPath GCA_900093555.2/GCA_900093555.2.2bit
+organism Plasmodium_vivax
+defaultPos LT635625.2:1264700-1277700
+scientificName Plasmodium vivax
+htmlPath GCA_900093555.2/description.html
+```
+
+### Track Hub record (existing UCSC assembly)
+
+```
+genome hg38
+trackDb hg38/trackDb.txt
+```
+
+That's the whole record. Track hubs are far easier to ship; reach for an assembly hub only when the target genome isn't already in UCSC.
+
+## Validation pitfalls
+
+- **Path resolution**: every relative path is relative to the directory containing `genomes.txt`, not to the hub root. If `genomes.txt` is at `hub/genomes.txt`, `twoBitPath GCA_X/GCA_X.2bit` resolves to `hub/GCA_X/GCA_X.2bit`.
+- **Symlinks**: relative symlinks for `.2bit` are fine if you're publishing via `rsync` (which dereferences by default). `rclone copy --copy-links` works too. `cp -d` keeps symlinks and breaks them at the destination — avoid.
+- **`defaultPos` not on a real contig**: `hubCheck` will pass but the browser jumps nowhere. Pick a contig you've confirmed with `twoBitInfo {ACC}.2bit stdout | head`.
+- **Spaces in `organism`**: use underscores. UCSC parses the rest of the line as the value but downstream pages break on raw spaces.
+- **Missing blank line between records**: `hubCheck` reports the second record as malformed. One blank line separator is required.
+
+## Building `genomes.txt` from a Galaxy workflow
+
+A `build_genomes_txt` tool should accept:
+
+- A collection of assemblies with their accessions, `.2bit` files, and `.sizes` files
+- A `defaultPos` mapping (e.g. a TSV: `accession\tcontig:start-end`)
+- The species name (used for `organism`, `scientificName`)
+- Optional `htmlPath`s
+
+…and emit a single `genomes.txt`. The most common cause of a working-but-empty hub is a missing or empty `defaultPos`, so the tool should refuse to emit a record where `defaultPos` is empty rather than letting it through.

--- a/trackhubs/references/hubcheck-debugging.md
+++ b/trackhubs/references/hubcheck-debugging.md
@@ -1,0 +1,69 @@
+# `hubCheck` errors and what they mean
+
+`hubCheck` (from kentUtils) validates a hub against UCSC's schema before publishing. Run it with `-level=warn` to catch the soft issues that still load but break behavior.
+
+```bash
+hubCheck -level=warn file:///path/to/hub.txt           # local
+hubCheck -level=warn https://my.cdn/hub/hub.txt        # public
+```
+
+`hubCheck` exits non-zero only on errors. Warnings still print but pass exit code. Read every warning.
+
+## Errors
+
+| Error | Cause | Fix |
+|---|---|---|
+| `Can't find genomesFile genomes.txt` | `hub.txt` references the wrong relative path | check the `genomesFile` line in `hub.txt` |
+| `type mismatch in compositeTrack` | composite contains sub-tracks of different `type`s | split into one composite per type (see `composite-tracks.md`) |
+| `unknown track type X` | typo or made-up type — common: `chain` (should be `bigChain`), `maf` (should be `bigMaf`) | use a real type from the [supported list](https://genome.ucsc.edu/goldenPath/help/trackDb/trackDbHub.html) |
+| `parent track Y not found` | sub-track has `parent Y` but no track `Y` exists, or Y is not a composite/superTrack | check the parent name spelling; ensure the parent is declared before the child in the file |
+| `Required field defaultPos missing or empty` | `defaultPos` line is blank or absent from `genomes.txt` | set a real `chrN:start-end` |
+| `Can't find twoBit file …` | `.2bit` path in `genomes.txt` resolves to nothing | build with `faToTwoBit`, fix the relative path |
+| `bigDataUrl … not found` | track's binary file is missing or wrong relative path | verify the file exists at the path `trackDb.txt` declares |
+| `Can't open bigBed file …: header byte not valid` | the file isn't actually a bigBed (e.g. trying to use `.bed`, `.bed.gz`, or `.chain.gz` as `bigDataUrl`) | rebuild with `bedToBigBed` (or appropriate big-format converter) |
+| `compositeTrack lines must come before sub-tracks` | composite header is below its members | move the composite parent stanza to before its children |
+
+## Warnings
+
+| Warning | What it means | Should you fix it? |
+|---|---|---|
+| `track has no shortLabel` | UI will show a default label | yes, always — labels are mandatory in practice |
+| `bigMaf has no .bb.bai index` | mafIndex companion missing; range queries are slow | optional but recommended for genome-scale views |
+| `vcfTabix file has .csi index, expected .tbi` | UCSC's `vcfTabix` only reads Tabix `.tbi` | yes — re-index with `bcftools index -t` or `tabix -p vcf` |
+| `bigChain has no linkDataUrl` | track will load but draw nothing | yes — bigChain is a paired-file format |
+| `assembly hub: no description.html for genome X` | UI shows blank assembly info | cosmetic, recommended for public hubs |
+
+## Debugging recipes
+
+### Hub loads but a track is silently missing
+
+`hubCheck` passed but the track doesn't appear. Most common causes:
+
+1. **Wrong `type`**: e.g. `type chain` with a `.chain.gz` file. UCSC silently drops unknown types from the trackDb. Check that `type` is a [supported type](https://genome.ucsc.edu/goldenPath/help/trackDb/trackDbHub.html).
+2. **Empty `bigDataUrl` target**: the file exists but is 0 bytes. Check `ls -la` on the path.
+3. **Wrong companion index**: bigChain without `.link.bb`, bigMaf without `.bb.bai` (sometimes), `vcfTabix` with `.csi` instead of `.tbi`. Track loads at zero items.
+4. **Region has no data**: try `defaultPos` from a contig you know carries data.
+
+### Hub loads but jumps to a blank page
+
+The browser opens but shows "no data" or a blank ideogram:
+
+1. `defaultPos` points at a contig name not in the `.2bit`. Dump contig names with `twoBitInfo {ACC}.2bit stdout | head` and pick one that exists.
+2. `defaultPos` range is past the end of the contig. Verify with `twoBitInfo`.
+
+### Hub is too slow at default zoom
+
+Default zoom over a whole genome with un-indexed tracks chokes:
+
+1. Build `.bb.bai` index for every bigMaf (`mafIndex` from kentUtils).
+2. Tabix-index every VCF (`tabix -p vcf`).
+3. Sort BED inputs to `bedToBigBed` before conversion.
+4. Set `visibility hide` on rarely-used tracks (chains, secondary alignments) so they don't auto-render.
+
+## Workflow integration
+
+When wrapping a hub-publishing workflow:
+
+1. Run `hubCheck -level=warn` as the **last** workflow step before declaring the hub ready.
+2. Fail the workflow on any warning. The default `-level=error` is too permissive — the silent-failure warnings above are exactly the ones that bite users.
+3. Persist `hubCheck` stdout to a workflow output so reviewers can audit.


### PR DESCRIPTION
## Summary

New top-level skill family `trackhubs/` covering UCSC Track Hub and Assembly Hub publishing. Distilled from real review feedback on a hub for the BRC-analytics *Plasmodium vivax* pangenome (galaxyproject/brc-analytics#1279).

## What problem does this solve?

LLMs reliably hallucinate UCSC track-hub configs in four recurring ways:

1. `type chain` (not a real type) with a `.chain.gz` file (text, not indexed)
2. `bigMaf` + `bigChain` in the same composite (composites must be single-type)
3. Empty `defaultPos` in `genomes.txt` (silent failure)
4. Missing companion files (`.bb.bai`, `.bigChain.link.bb`, `.tbi` instead of `.csi`)

All four pass at `hubCheck`'s default error level but break user-facing behavior. The skill encodes the lessons so the next workflow gets them right the first time.

## What's in it?

- **`SKILL.md`** — entry point, quick reference, workflow, common pitfalls
- **`references/composite-tracks.md`** — the single-type rule; superTrack vs. compositeTrack vs. multiWig
- **`references/chain-to-bigchain.md`** — full chain → bigChain Python script + `bedToBigBed` recipe with `bigChain.as` and `bigLink.as` schemas
- **`references/genomes-txt-fields.md`** — assembly-hub vs. track-hub fields, every line of `genomes.txt` explained
- **`references/hubcheck-debugging.md`** — `hubCheck` error/warning catalog with silent-failure cases called out

Also adds `trackhubs/` to the skill-categories table in `CONTRIBUTING.md`.

## How was it tested?

Real-world: every guardrail in the skill maps to an error that was actually shipped and then caught at PR review on brc-analytics#1279. After applying the rules described here, all 8 hubs for the *P. vivax* pangenome (1 standalone bigMaf + bigChain composite + bigBed12 composite + selection composite per hub × 8 assemblies = 56 bigChain pairs) build cleanly.

## Example usage

A workflow that emits a UCSC hub for any species:

```yaml
steps:
  - chain_to_bigchain    # parses chain → bigChain.bed + bigLink.bed
  - bedToBigBed × 2      # one for each schema (-as=bigChain.as / bigLink.as)
  - mafToBigMaf          # standalone bigMaf, not in chain composite
  - build_trackdb        # 1 standalone + N composites grouped by type
  - build_genomes_txt    # 9 required fields, refuses to emit empty defaultPos
  - hubCheck -level=warn # fail workflow on any warning, not just error
```

The skill includes the script that does the chain → bigChain conversion in one pass (no `hgLoadChain` dependency).