### PR TITLE
Add gotcha: omitting optional parameter_input steps when invoking workflows produces ConnectedValue placeholder errors

### DIFF
--- a/galaxy-integration/mcp-reference/gotchas.md
+++ b/galaxy-integration/mcp-reference/gotchas.md
@@ -69,6 +69,36 @@ invoke_workflow(
 - `hdca` = HistoryDatasetCollectionAssociation (collection)
 - `ldda` = LibraryDatasetDatasetAssociation
 
+## Optional Parameter Inputs Must Be Explicit
+
+**Problem**: Omitting an optional `parameter_input` step from the `inputs` dict causes downstream tools to receive an unresolved `ConnectedValue` placeholder, producing command lines with literal garbage like `'Xgalaxy.tools.parameters.workflow_utils.ConnectedValue object at 0x...X'` and tool failures with cryptic exit codes.
+
+**Solution**: Always pass an explicit value for **every** `parameter_input` step in the workflow, even ones marked `optional: true`. Use `""` for empty text, `null` for empty data inputs:
+
+```python
+# WRONG - inputs 1 and 2 (optional adapter sequences) omitted
+inputs = {
+    "0": {"src": "hdca", "id": collection_id},
+    "5": {"src": "hda", "id": gtf_id},
+    "6": "stranded - reverse",
+    # ...
+}
+
+# CORRECT - explicit empty strings for optional text params
+inputs = {
+    "0": {"src": "hdca", "id": collection_id},
+    "1": "",                          # Forward adapter (optional)
+    "2": "",                          # Reverse adapter (optional)
+    "5": {"src": "hda", "id": gtf_id},
+    "6": "stranded - reverse",
+    # ...
+}
+```
+
+**How to verify before invoking**: call `get_workflow_details(workflow_id)` and check the `inputs` dict — every numeric key (step index) of type `parameter_input` needs a corresponding entry in your `inputs`, regardless of `optional` status.
+
+**How to diagnose after failure**: if a tool fails with no obvious stderr cause, fetch `get_job_details(dataset_id)` and inspect `command_line` for the string `ConnectedValue object at 0x`. That signature confirms the omitted-optional-input bug.
+
 ## Connection Issues
 
 ```python


### PR DESCRIPTION
## Problem

When invoking an IWC workflow via `invoke_workflow` (MCP) or `POST /api/workflows/{id}/invocations` (API), workflow inputs of type `parameter_input` that are declared `optional: true` must still be passed an explicit value (typically `""` for empty text). If you omit them from the `inputs` dict, the workflow scheduler leaves the downstream tool's connected slot as an unresolved `ConnectedValue` Python object reference, and the tool's command line ends up containing literal garbage like:

```
--adapter_sequence 'Xgalaxy.tools.parameters.workflow_utils.ConnectedValue object at 0x7f46e05c5810X'
```

…which makes the tool fail with non-obvious errors (`fastp`: exit 255; the actual cause is buried in the command line, not the stderr).

## Reproduction

Invoking `iwc-workflows/rnaseq-pe/main` (v1.3) with this input dict:

```python
inputs = {
    "0": {"src": "hdca", "id": COLLECTION_ID},
    "3": True,
    "4": "GCA_002759435.3",
    "5": {"src": "hda", "id": GTF_ID},
    "6": "stranded - reverse",
    "7": True, "8": False, "10": True,
    # Note: inputs 1 (Forward adapter) and 2 (Reverse adapter) omitted — both are optional text parameter_inputs
}
```

…silently passes a `ConnectedValue` placeholder downstream and all 6 fastp jobs fail with exit code 255. Adding `"1": ""`, `"2": ""` to the dict fixes it.

## Why it's hard to debug

- The workflow invocation reports `state: ready` initially (no schema validation rejects the omission).
- Job stderr doesn't mention the placeholder — you have to look at `command_line` in the job details.
- The Galaxy UI's "Run Workflow" form would silently default these to empty, so this only bites API/MCP users.

## Change

Adds an **Optional Parameter Inputs Must Be Explicit** section to `galaxy-integration/mcp-reference/gotchas.md` (after "Workflow Input Mapping") documenting the problem, the workaround, and how to verify before / diagnose after.

This is the workflow-invocation flavor of the silent-failure trap the collection-manipulation skill warns about in spirit; it isn't documented anywhere yet and likely hits everyone exactly once on their first IWC workflow run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)