### PR TITLE
Tag collection-manipulation and galaxy-mcp-reference for the Loom surface

### DIFF
--- a/collection-manipulation/SKILL.md
+++ b/collection-manipulation/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: galaxy-transform-collection
 description: Galaxy Collection Transformation Command - transform Galaxy dataset collections reproducibly using Galaxy's native tools. Use when asked to filter, sort, relabel, restructure, flatten, nest, merge, or otherwise manipulate Galaxy collections.
+metadata:
+  surfaces: [loom]
 user_invocable: true
 ---
 

--- a/galaxy-integration/mcp-reference/SKILL.md
+++ b/galaxy-integration/mcp-reference/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: galaxy-mcp-reference
 description: Galaxy MCP server tools reference for histories, datasets, tools, and workflows
+metadata:
+  surfaces: [loom]
+when_to_use: >
+  Reach for this before any Galaxy MCP tool call -- creating/listing histories,
+  uploading data, finding and running tools, inspecting datasets or invocations --
+  and for the common gotchas (id vs name, history vs dataset ids, collection shapes).
 user_invocable: true
 ---
 

--- a/workflow-reports/SKILL.md
+++ b/workflow-reports/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: workflow-reports
 description: Use this skill when asked to create, draft, or write a Galaxy workflow report template for the Workflow Editor's Report tab. Triggers on requests like "create a report for this workflow", "draft a workflow report template", "write a Galaxy report for workflow <id/url>".
+metadata:
+  surfaces: [loom]
 ---
 
 # Galaxy Workflow Report Templates


### PR DESCRIPTION
Adds a `metadata.surfaces: [loom]` frontmatter entry to `collection-manipulation/SKILL.md` and `galaxy-integration/mcp-reference/SKILL.md`, plus a top-level `when_to_use` trigger on the MCP reference (its description was a bare noun phrase with no "use when…" cue).

## Why

Loom is moving off a hardcoded list of which galaxy-skills it exposes and onto reading this tag straight from frontmatter. A skill opts into being surfaced in Loom by declaring `surfaces: [loom]`. That keeps the curation -- the analysis-orchestration slice Loom cares about -- living in the skills themselves instead of in a copy inside Loom's binary that drifts from this repo.

## Scope

Just these two for now, which is the set Loom surfaces today. `workflow-reports` gets the same tag when that branch lands.

## Compatibility

`surfaces` is a custom (non-standard) key, so it lives under the Agent-Skills `metadata` object rather than at the top level -- the spec-recommended place for properties outside the standard. Unknown metadata is ignored by Claude Code's plugin system and other consumers, so this is a no-op for the marketplace proposal (#7) and the Agent-Skills standard. `when_to_use` is a recognized Claude Code field, so it stays top-level.

If a future restructure moves these skills under `skills/`, the tags travel with the files and Loom's discovery (a recursive `SKILL.md` walk) follows automatically.
