### PR TITLE
Add project-review skill (stub)

### DIFF
--- a/project-review/README.md
+++ b/project-review/README.md
@@ -1,0 +1,31 @@
+# Project Review Skill
+
+Claude Code skill for reviewing Galaxy Project repositories against a profile of best-practice expectations and producing a short, one-line-per-criterion report.
+
+## Quick Start
+
+Point Claude at a repo: *"Review planemo against project best practices"* or *"project review for galaxyproject/gxformat2"*.
+
+Claude picks a profile, assesses each criterion, and emits one row per line — verdict (pass / needs work / n/a) plus a terse justification citing the relevant file or workflow.
+
+## Profiles
+
+- **General** — any project. README, MIT license, GitHub Actions (zizmor-clean), and trusted publishing for projects that publish artifacts.
+- **Standard Python** — General plus mypy-in-CI and Sphinx docs. Applies to `pulsar`, `planemo`, `gxformat2`, `ephemeris`.
+
+The Python profile is a superset of General; pick the most specific one that fits.
+
+## Files
+
+- `SKILL.md` — the profiles and review criteria.
+- `references/github-actions.md` — how the GitHub Actions line is checked with [zizmor](https://docs.zizmor.sh/), with `galaxyproject/galaxy#22827` as the exemplar.
+
+## Installation
+
+```bash
+# Personal skills (all projects)
+ln -s /path/to/project-review ~/.claude/skills/project-review
+
+# Project skills (shared via git)
+ln -s /path/to/project-review .claude/skills/project-review
+```

--- a/project-review/SKILL.md
+++ b/project-review/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: project-review
+description: Use this skill when asked to review a Galaxy Project repository against best practices — README, license, CI/GitHub Actions, and (for standard Python projects like pulsar, planemo, gxformat2, ephemeris) mypy, Sphinx docs, and trusted publishing. Triggers on "review this project", "project review for <repo>", "does <repo> follow best practices".
+---
+
+# Galaxy Project Review
+
+Review a Galaxy Project repository against a profile of expectations. Produce a short report — one line per criterion with a verdict (pass / needs work / n/a) and a terse justification. Avoid boilerplate explanations of *why* a practice is good; assume a capable reader and just assess.
+
+Where a criterion has a tool that checks it, **run the tool** and base the verdict on its output rather than eyeballing — currently the GitHub Actions line (run zizmor; see `references/github-actions.md`).
+
+## Profiles
+
+Pick the most specific profile that applies. The **Python** profile is the **General** profile plus extra lines.
+
+### General (any project)
+
+- Follows relevant best practices.
+- Has an updated and relevant README file (e.g. README.md, README.rst, or README).
+- Has an updated MIT license (excluded projects include TODO).
+- Has relevant and updated GitHub Actions; workflows are zizmor-clean (see `references/github-actions.md`).
+- If the project publishes artifacts, uses trusted publishing and has easy-to-find documentation for the publishing process.
+
+### Standard Python (pulsar, planemo, gxformat2, ephemeris)
+
+All **General** lines, plus:
+
+- Has mypy enabled, checked in CI, and updated.
+- Has Sphinx docs enabled and published somewhere.
+
+## Output
+
+For each line in the selected profile, emit one row: criterion, verdict, one-sentence justification (cite a file/path/workflow when relevant).

--- a/project-review/references/github-actions.md
+++ b/project-review/references/github-actions.md
@@ -1,0 +1,33 @@
+# GitHub Actions review
+
+The General-profile line *"Has relevant and updated GitHub Actions; workflows are zizmor-clean"* is checked with [zizmor](https://docs.zizmor.sh/), a static-analysis security linter for GitHub Actions workflows.
+
+Language-agnostic: zizmor is a Rust tool that audits `.github/workflows/*`, action definitions, and `dependabot.yml`. It does not parse application source, so it applies to every Galaxy Project repo regardless of language (Python, JS/TS, Rust, docs-only).
+
+## Running it
+
+Running zizmor against the checkout **is part of the review** — base the verdict on its findings, not a visual scan of the YAML.
+
+```bash
+# one-off, no install (PyPI is just a distribution channel)
+uvx zizmor .
+```
+
+Notes:
+- Offline (default) audits need no credentials. Some audits are online (e.g. `known-vulnerable-actions`, `impostor-commit`) and need a GitHub token — `GH_TOKEN=$(gh auth token) uvx zizmor .` to include them. If no token is available, say so and report only the offline result.
+- A separate concern from the per-repo lint is whether the repo *wires zizmor into its own CI* so workflow changes are linted on every push/PR. The exemplar is **galaxyproject/galaxy#22827**, which adds `.github/workflows/zizmor.yaml` and a root `zizmor.yml` config, then fixes everything it flagged. A fully clean verdict means both: zizmor passes *and* it runs in the project's CI.
+
+## What a clean result looks like
+
+The hardening zizmor pushes toward (all generic, not Galaxy-specific):
+
+- Third-party actions pinned to a commit SHA with a `# vX.Y.Z` comment.
+- Top-level `permissions: {}` (least-privilege token), widened only per-job where needed.
+- `persist-credentials: false` on `actions/checkout` steps that don't need the token.
+- No template injection of `${{ ... }}` into `run:` shell bodies.
+- Dependabot cooldown configured.
+- Genuine false positives suppressed inline with `# zizmor: ignore[<rule>]` (and ideally a reason).
+
+## Ties into the publishing line
+
+zizmor's `use-trusted-publishing` audit flags publish workflows that use manual API tokens where OIDC trusted publishing is available — so a clean zizmor run also gives evidence for the General publishing line, not just this one.


### PR DESCRIPTION
I hate how bad a job I do keeping planemo/pulsar/gxformat2/etc... in line with each other. I really liked the zizmor work from @nsoranzo in https://github.com/galaxyproject/galaxy/pull/22827. I want to start to off load this task to an agent. Starting with zizmor here to see if I can use this skill to add that consistently across these projects. If that works we can add more and more challenging checks. I have a dozen smaller Python one-off projects that hopefully could be brought up to speed quickly if we get this working.

Two profiles: General (any project) and Standard (galaxy-style?, planemo-style?, bioblend-style?, not sure what to call it) Python (pulsar/planemo/gxformat2/ephemeris adds mypy + Sphinx). GitHub Actions line checked by running zizmor; references galaxyproject/galaxy#22827 as exemplar.
