### PR TITLE
Add reproduciblify skill; sync directive references from upstream Galaxy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ If the user asks to create, draft, or write a Galaxy workflow report template fo
   - `workflow-reports/SKILL.md` (single self-contained skill)
 
 - References:
-  - `workflow-reports/references/directives.md` (Galaxy markdown directive reference)
+  - `workflow-reports/references/directives.md` (Galaxy markdown directive reference, synced from upstream Galaxy via `make sync-directives`)
   - `workflow-reports/examples/histology-staining.md` (worked example: imaging quantification)
   - `workflow-reports/examples/tissue-microarray-analysis.md` (worked example: multiplex tissue analysis)
 
@@ -94,6 +94,18 @@ If the user asks to create a tool they (a non-admin) can define and run in their
   - `udt-authoring/references/common-mistakes.md` (pre-submit self-review checklist)
   - `udt-authoring/scripts/validate.py` (offline validate + lint via galaxy-tool-util)
   - `udt-authoring/examples/` (seven complete UDTs, simple to complex)
+
+## Reproduciblify
+
+If the user asks to "reproduciblify" a Galaxy history, rebuild a messy analysis on-graph, or turn a history into a clean Galaxy Notebook that extracts into a reusable workflow:
+
+- Skill:
+  - `reproduciblify/SKILL.md` (single self-contained skill)
+
+- References:
+  - `reproduciblify/references/directives.yml` (machine-readable Galaxy markdown directive metadata, synced from upstream Galaxy via `make sync-directives`)
+
+Depends on `galaxy-integration` (MCP access), `collection-manipulation` (map/reduce restructuring), `tool-dev` (creating tools as a fallback), and `workflow-reports` (markdown directives for embedding on-graph artifacts).
 
 ## Other skills in this repo
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+# Galaxy Skills maintenance tasks.
+
+# Synchronize the Galaxy Markdown directive references vendored into skills.
+#
+# Source of truth: client/src/components/Markdown/directives.{yml,md} in
+# galaxyproject/galaxy. directives.md is generated from directives.yml upstream
+# (make client-gen-markdown-directives); both are "do not edit by hand" here — to
+# change content, change it in Galaxy and re-sync.
+#
+# Each skill vendors exactly one form (no duplicated content across a skill):
+# workflow-reports uses the human-readable directives.md; reproduciblify uses the
+# machine-readable directives.yml.
+#
+# Override the source to pull from an unmerged branch, e.g.:
+#   make sync-directives GALAXY_REPO=jmchilton/galaxy GALAXY_REF=directives
+GALAXY_REPO ?= galaxyproject/galaxy
+GALAXY_REF  ?= dev
+GALAXY_RAW  := https://raw.githubusercontent.com/$(GALAXY_REPO)/$(GALAXY_REF)
+DIRECTIVES_SRC  := client/src/components/Markdown
+
+# Each entry is <dest-dir>:<filename> — maps an upstream directives file to the
+# one skill that consumes it.
+DIRECTIVE_TARGETS := workflow-reports/references:directives.md reproduciblify/references:directives.yml
+
+.PHONY: sync-directives
+sync-directives:
+	@for pair in $(DIRECTIVE_TARGETS); do \
+		dir=$${pair%%:*}; f=$${pair##*:}; \
+		mkdir -p $$dir; \
+		echo "$(GALAXY_REPO)@$(GALAXY_REF): $$f -> $$dir/$$f"; \
+		curl -fsSL "$(GALAXY_RAW)/$(DIRECTIVES_SRC)/$$f" -o "$$dir/$$f"; \
+	done
+	@echo "Synced from $(GALAXY_REPO)@$(GALAXY_REF)"

--- a/reproduciblify/SKILL.md
+++ b/reproduciblify/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: reproduciblify
+description: Use this skill to "reproduciblify" a Galaxy history — re-execute a real (often messy) analysis as a clean, fully on-graph, collection-structured history and author a Galaxy Notebook that extracts cleanly into a reusable, sample-agnostic workflow. Triggers on "reproduciblify this history", "make this history reproducible/extractable", "rebuild this analysis on-graph", "turn this history into a clean notebook/workflow".
+---
+
+# Reproduciblify
+
+Take a real Galaxy history — often messy, with manual uploads of derived data, pasted figures, off-graph scratch steps, and one-sample-at-a-time structure — and **reproduciblify** it: re-execute the analysis so its entire computational closure lives on the Galaxy provenance graph, restructure it with collections for arbitrary arity, and author a **Galaxy Notebook** that documents it and extracts cleanly into a reusable, sample-agnostic workflow.
+
+A Galaxy Notebook is a history-attached Galaxy-flavored markdown document. It documents an analysis and embeds its on-graph artifacts via directives; it does not execute anything. Its value here is that notebook-driven workflow extraction can recover a reusable workflow from the artifacts it references.
+
+## When to Use
+
+- The user has a Galaxy history (and optionally the plan/recipe/transcript that produced it) and wants it turned into something durable and reusable.
+- The history "works" but was built ad-hoc: data computed outside Galaxy and uploaded, figures pasted as images, bash/manual steps, single-sample structure that should generalize.
+- The goal is a clean Galaxy Notebook **and** a workflow that re-runs the documented analysis on new data.
+
+If the user only wants a report template for an *already-clean* workflow, use `workflow-reports` instead. If they only want to manipulate collections, use `collection-manipulation`.
+
+## The Core Principle: extractability = everything on-graph
+
+Galaxy's notebook-driven workflow extraction walks **backward through the history provenance graph** from the artifacts a notebook references. It can only recover the computation behind artifacts the history actually produced as tool outputs.
+
+This gives one hard test every step must pass:
+
+> **Can Galaxy walk backward from this artifact, through real Galaxy jobs, to a logical input?**
+
+Things that **fail** the test and anchor nothing:
+- Data computed outside Galaxy and uploaded (a count matrix made in R/Python, a gene list made by a local script).
+- Figures pasted as images rather than emitted by an on-graph plotting tool.
+- Bash / "scratch" / manual reformatting steps done outside the tool framework.
+
+Things that **pass**:
+- A logical input dataset (raw reads, a public matrix that is the genuine starting boundary of the analysis).
+- Any derived artifact produced by a real Galaxy tool run.
+
+Reproduciblify is the act of converting every failing step into a passing one — replacing off-graph computation with on-graph tools — and structuring the result so it generalizes.
+
+## Required Input
+
+1. **A Galaxy history** (required). Connect via the Galaxy MCP server and inspect it — see `galaxy-integration/mcp-reference/SKILL.md`. The relevant calls: `get_history_contents`, `get_dataset_details` (with preview), `get_job_details` (the job that produced each dataset, including its inputs and tool id).
+2. **A plan / recipe / transcript** (optional but valuable). If the user has the steps that produced the history — a methods note, a chat log, an SI recipe — use it to recover *intent*: which steps were exploratory dead-ends, which outputs mattered, why parameters were chosen. The history shows *what happened*; the recipe helps recover *what was meant*.
+
+## Workflow
+
+### Step 1 — Map the source history
+
+Enumerate every dataset and the job that produced it. Classify each node:
+
+| Class | Meaning | Action |
+|-------|---------|--------|
+| **Logical input** | The genuine starting boundary of the analysis (raw reads, a public reference matrix) | Keep as an upload/input |
+| **On-graph derived** | Produced by a real Galaxy tool job | Keep — already extractable |
+| **Off-graph intrusion** | Uploaded derived data, pasted figure, bash/manual step | **Must be replaced** with an on-graph tool (Step 3) |
+| **Dead-end / exploratory** | Abandoned branch, superseded attempt | Drop from the clean rebuild |
+
+Also identify the **meaningful outputs** — the datasets/figures/tables that *are the answer* and will anchor the notebook (and therefore the extraction).
+
+### Step 2 — Plan the notebook
+
+Write a plan (share it with the user before executing). Structure it as:
+
+```
+logical inputs  →  ordered on-graph steps  →  meaningful outputs
+```
+
+Decide arity up front: is this a single-sample analysis that should generalize to N samples? Where does map-over belong? Where is there a reduce/pairwise seam (a comparison between groups)? See Step 4.
+
+This plan is the spine of both the rebuilt history and the notebook narrative.
+
+### Step 3 — Replace off-graph computation with on-graph tools
+
+For every off-graph intrusion from Step 1, the rule is **find superior, create as fallback**:
+
+1. **Find (preferred).** Search for an existing Galaxy tool that performs the computation: `search_tools_by_name`, `search_tools_by_keywords`, `get_tool_panel`, and the IWC manifest. Prefer a well-maintained Tool Shed tool over a bespoke one — it is more reproducible, citable, and recognizable to reviewers.
+2. **Create (fallback).** If no suitable tool exists, build one. Use the `tool-dev` skill (`tool-dev/SKILL.md`) — wrap the script/computation as a proper Galaxy tool with declared inputs, outputs, and a test, and place it per `tool-dev/references/tool-placement.md`.
+
+After this step, **only genuine logical inputs remain as uploads.** Everything else is a tool output.
+
+> Worked example: an analysis of "six uploads, six alignments, a bash gene-list step, and a pasted matrix" collapses into a clean all-tool DAG once the bash step becomes a tool and the matrix becomes an on-graph tool output. The pasted matrix anchored nothing until it was made on-graph.
+
+### Step 4 — Restructure for arity with collections
+
+If the analysis should accept an arbitrary number of samples, encode that with Galaxy **collections** and map/reduce structure rather than copy-pasted per-sample steps. See `collection-manipulation/SKILL.md`.
+
+- **Map-over** — a per-sample step runs once per collection element. N samples in → N results out, with no change to the workflow graph.
+- **Nested `list:list`** — carry experimental design *structurally* through collection shape (e.g. outer level = condition, inner level = replicate). This lets one MACS2/DESeq2-style step map over conditions while pooling replicates, with no metadata-aware tooling. A hand-authored sample sheet is the ideal description of design, but it is **not** an extraction target — the nested collection is.
+- **Reduce / pairwise seams** — a step that compares two specific groups is a reduce. If it selects named elements out of a collection and feeds a single-dataset tool input, it has **no representation as a workflow edge** — it is an *irreducible comparison*.
+
+**The irreducible-comparison rule:** when a seam can't be made sample-agnostic inside one workflow, don't force it. Split into two reusable pieces — a **map-over producer** (collections in, per-group results out) and a **pairwise comparator** (any two results in, differential out). Only their composition (which two groups to contrast) stays analyst-supplied. Surface this boundary to the user explicitly rather than hiding it.
+
+### Step 5 — Re-execute the clean pipeline on Galaxy
+
+Galaxy Notebooks are **not** executable — execution stays in real Galaxy tools, histories, and workflows. So actually run the rebuilt pipeline via MCP (`run_tool`) into a fresh history, in the order from the plan, verifying each step emits a real on-graph output. Produce every meaningful output — including every figure — as a genuine tool run (e.g. `ggplot2_*`, plotting tools that emit image outputs), never as a pasted image.
+
+> A figure emitted as PDF can be brought on-graph as an image output and referenced directly — so even "plot" steps seed extraction.
+
+### Step 6 — Author the Galaxy Notebook
+
+Create a history-attached notebook (a Page with `history_id` set) via the Galaxy MCP page tools (`create_page` with the history id, `update_page` to revise; edits are recorded as `edit_source="agent"`). Write Galaxy-flavored markdown that:
+
+- Narrates **logical inputs → steps → meaningful outputs**, recording *why* choices were made (the communicative record the history alone can't hold).
+- **Embeds every meaningful output as a real on-graph directive** — `history_dataset_as_image(output=...)`, `history_dataset_as_table(...)`, etc. Every embedded artifact must be an on-graph tool output. For the directive syntax and full catalog, see `references/directives.yml`.
+
+The discipline is identical to a good workflow report, but stricter: here, every referenced artifact *is* an extraction anchor, so a pasted figure is not just poor documentation — it is a hole in the recoverable workflow.
+
+### Step 7 — Verify extractability
+
+Before declaring done:
+
+- **Audit anchors:** every artifact the notebook references is an on-graph tool output. Zero pasted figures, zero uploaded derived data.
+- **Walk backward:** mentally (or by extracting) trace each meaningful output back through jobs to a logical input. No dangling inputs.
+- **Check generality:** the recovered workflow should be sample-agnostic — passing the input collection (not its individual element datasets) keeps the input surface clean; a larger/fresh cohort re-runs without edits.
+- **Extract and re-run** (if the instance supports it) and confirm the result is science-identical to the original. Byte-identical is the gold standard for a clean map-over pipeline.
+
+## Decision Cheat-Sheet
+
+| Situation | Do this |
+|-----------|---------|
+| Derived data was uploaded from outside Galaxy | Find a superior Galaxy tool; create one (`tool-dev`) only as fallback |
+| A figure is a pasted image | Re-emit it from an on-graph plotting tool |
+| A bash/manual reformatting step | Wrap it as a Galaxy tool, or find a native equivalent |
+| Analysis is one-sample, should be N-sample | Map-over a list collection |
+| Experimental design (condition × replicate) | Nested `list:list` collection — carry design through shape |
+| A step compares two named groups | It's a reduce; if irreducible, **split** into map-over producer + pairwise comparator |
+| An exploratory dead-end branch | Drop it from the clean rebuild |
+
+## Common Mistakes
+
+| Mistake | Why it's wrong | Fix |
+|---------|----------------|-----|
+| Documenting the messy history as-is | Off-graph anchors aren't extractable; the notebook looks reproducible but isn't | Rebuild on-graph first, then document |
+| Pasting a figure into the notebook | Anchors nothing for extraction | Emit it from a tool as an image output |
+| Forcing an irreducible comparison into one workflow | Produces a condition-pinned workflow that can't generalize | Split into producer + comparator; surface the seam |
+| Passing collection *element datasets* as workflow inputs | Bloats and pins the input surface | Pass the collection itself |
+| Treating the notebook as executable | Galaxy Notebooks are narrative, not execution | Run real tools to build the history, then narrate |
+| Creating a new tool when a good one exists | Less reproducible, less recognizable, more maintenance | Search first; create only as fallback |
+
+## See Also
+
+- `galaxy-integration/mcp-reference/SKILL.md` — Galaxy MCP tools (history/dataset/tool/page access, `run_tool`).
+- `collection-manipulation/SKILL.md` — map/reduce restructuring with native collection tools.
+- `tool-dev/SKILL.md` — building a Galaxy tool when no suitable one exists (fallback path).
+- `references/directives.yml` — Galaxy markdown directive metadata for embedding on-graph artifacts (synced from upstream Galaxy via `make sync-directives`).

--- a/reproduciblify/references/directives.yml
+++ b/reproduciblify/references/directives.yml
@@ -1,0 +1,496 @@
+---
+# Metadata describing every Galaxy Markdown directive.
+#
+# Consumed at runtime by directives.ts (editor side panel) and used to generate the
+# human-readable reference directives.md via scripts/markdown_directives_doc.py.
+# The parameter, embeddable and requirement metadata here is checked against the
+# authoritative validator in lib/galaxy/managers/markdown_parse.py (and
+# Utilities/requirements.yml) by test/unit/app/test_markdown_directives_doc.py, so
+# keep them in sync.
+#
+# Keys starting with "_" are shared schema fragments, not directives.
+#
+# Per-directive fields:
+#   category        grouping used in the generated reference
+#   renders         one-line summary of the rendered output
+#   embeddable      true when usable inline via ${galaxy ...} (EMBED_CAPABLE_DIRECTIVES)
+#   requires        primary object the directive needs (mirrors requirements.yml)
+#   parameter_set   name of a shared bundle under _parameter_sets to include
+#   parameters      directive-specific arguments (name -> type/default/context/description)
+#   dynamic_parameters  true when arbitrary arguments are accepted (not validated)
+# The shared arguments below are valid on every directive and documented globally.
+
+_shared_arguments:
+  - collapse
+
+_parameter_sets:
+  dataset_addressing:
+    output:
+      type: label
+      context: report
+      description: Workflow output label, resolved per invocation (report templates).
+    input:
+      type: label
+      context: report
+      description: Workflow input label, resolved per invocation (report templates).
+    hid:
+      type: int
+      context: notebook
+      description: History item hid.
+    history_dataset_id:
+      type: id
+      context: page
+      description: Encoded (export) or numeric (internal) dataset ID.
+    invocation_id:
+      type: id
+      context: invocation
+      description: Invocation ID; usually injected automatically during resolution.
+  collection_addressing:
+    output:
+      type: label
+      context: report
+      description: Workflow output label, resolved per invocation (report templates).
+    input:
+      type: label
+      context: report
+      description: Workflow input label, resolved per invocation (report templates).
+    hid:
+      type: int
+      context: notebook
+      description: History item hid.
+    history_dataset_collection_id:
+      type: id
+      context: page
+      description: Encoded or numeric dataset collection ID.
+    invocation_id:
+      type: id
+      context: invocation
+      description: Invocation ID; usually injected automatically during resolution.
+  job_addressing:
+    step:
+      type: label
+      context: report
+      description: Workflow step label, resolved per invocation (report templates).
+    job_id:
+      type: id
+      context: page
+      description: Encoded or numeric job ID.
+    implicit_collection_jobs_id:
+      type: id
+      context: page
+      description: Mapped-collection job group ID.
+    invocation_id:
+      type: id
+      context: invocation
+      description: Invocation ID; usually injected automatically during resolution.
+  workflow_addressing:
+    workflow_id:
+      type: id
+      context: page
+      description: Stored workflow ID.
+    workflow_checkpoint:
+      type: int
+      context: page
+      description: Workflow version index.
+    invocation_id:
+      type: id
+      context: invocation
+      description: Invocation ID; usually injected automatically during resolution.
+  invocation_addressing:
+    invocation_id:
+      type: id
+      context: invocation
+      description: Invocation ID; usually injected automatically during resolution.
+
+history_dataset_display:
+  category: dataset
+  renders: Interactive dataset card with view/import/download options.
+  embeddable: false
+  requires: history_dataset_id
+  parameter_set: dataset_addressing
+  side_panel_name: Dataset
+  help: |
+    Display a dataset and relevant options for viewing, importing, downloading,
+    and visualization in the resulting document. To embed a dataset directly
+    into the document use the "history_dataset_embedded" / "Embedded Dataset"
+    directive.
+
+history_dataset_collection_display:
+  category: collection
+  renders: Collection browser for paired/list collections.
+  embeddable: false
+  requires: history_dataset_collection_id
+  parameter_set: collection_addressing
+  side_panel_name: Collection
+  help: |
+    Display a dataset collection and relevant options for viewing, importing, downloading
+    in the resulting document.
+
+history_dataset_as_image:
+  category: dataset
+  renders: Dataset embedded as an image.
+  embeddable: true
+  requires: history_dataset_id
+  parameter_set: dataset_addressing
+  parameters:
+    path:
+      type: path
+      description: File within a composite / extra-files dataset.
+  side_panel_name: Image
+  help: |
+    Embed a dataset in the resulting document as an image. This only works for simple image
+    types. This can be used to present graphs and other visual summaries of an analysis into
+    a Galaxy Markdown document summary.
+
+history_dataset_index:
+  category: dataset
+  renders: File/folder listing of a composite dataset.
+  embeddable: false
+  requires: history_dataset_id
+  parameter_set: dataset_addressing
+  parameters:
+    path:
+      type: path
+      description: File within a composite / extra-files dataset.
+  side_panel_name: Dataset Index
+  help: |
+    For Galaxy composite datasets (datasets that consist on multiple files), this option will
+    display the contents of the composite dataset as files and folders in the resulting document.
+
+history_dataset_embedded:
+  category: dataset
+  renders: Raw dataset content inline.
+  embeddable: false
+  requires: history_dataset_id
+  parameter_set: dataset_addressing
+  side_panel_name: Embedded Dataset
+
+history_dataset_as_table:
+  category: dataset
+  renders: Tabular dataset as a formatted table.
+  embeddable: false
+  requires: history_dataset_id
+  parameter_set: dataset_addressing
+  parameters:
+    title:
+      type: string
+      description: Table title.
+    footer:
+      type: string
+      description: Table footer.
+    compact:
+      type: boolean
+      default: false
+      description: Compact row height.
+    show_column_headers:
+      type: boolean
+      default: true
+      description: Show column headers.
+    path:
+      type: path
+      description: File within a composite / extra-files dataset.
+  side_panel_name: Embedded Dataset as table
+  help: |
+    Embed a dataset in the resulting document as a table. This only works for datasets with tabular
+    datatypes. This command works a lot like "history_dataset_embedded" but provides specialized options
+    for controlling the way tabular data is displayed in the resulting document.
+
+history_dataset_type:
+  category: dataset
+  renders: Datatype string as text.
+  embeddable: true
+  requires: history_dataset_id
+  parameter_set: dataset_addressing
+  side_panel_name: Dataset Type
+
+history_dataset_link:
+  category: dataset
+  renders: Download link for a dataset.
+  embeddable: false
+  requires: history_dataset_id
+  parameter_set: dataset_addressing
+  parameters:
+    label:
+      type: string
+      description: Link text.
+    path:
+      type: path
+      description: File within a composite / extra-files dataset.
+  side_panel_name: Link to Dataset
+
+history_dataset_name:
+  category: dataset
+  renders: Dataset name as text.
+  embeddable: true
+  requires: history_dataset_id
+  parameter_set: dataset_addressing
+  side_panel_name: Name of Dataset
+
+history_dataset_peek:
+  category: dataset
+  renders: Dataset "peek" preview.
+  embeddable: false
+  requires: history_dataset_id
+  parameter_set: dataset_addressing
+  side_panel_name: Peek into Dataset
+  help: |
+    Display a dataset metadata's "peek" field in the resulting document - this is datatype dependent
+    metadata but usually this is a few lines from the start of a file.
+
+history_dataset_info:
+  category: dataset
+  renders: Dataset "info" metadata.
+  embeddable: false
+  requires: history_dataset_id
+  parameter_set: dataset_addressing
+  side_panel_name: Dataset Details
+  help: |
+    Display a dataset metadata's "info" field in the resulting document. This info field is
+    usually based on the output of the tool run and sometimes contains useful metadata about a
+    dataset.
+
+history_link:
+  category: invocation
+  renders: Link to import the referenced history.
+  embeddable: false
+  requires: history_id
+  parameters:
+    history_id:
+      type: id
+      context: page
+      description: Encoded or numeric history ID.
+    invocation_id:
+      type: id
+      context: invocation
+      description: Invocation ID; usually injected automatically during resolution.
+  side_panel_name: Link to Import
+  help:
+    report: |
+      Add a link to import the history the workflow invocation was executed in.
+    page: |
+      Add a link to import the target history referenced by the directive.
+
+invocation_inputs:
+  category: invocation
+  renders: Summary of all workflow inputs.
+  embeddable: false
+  requires: invocation_id
+  parameter_set: invocation_addressing
+  side_panel_name: Invocation Inputs
+
+invocation_outputs:
+  category: invocation
+  renders: Summary of all workflow outputs.
+  embeddable: false
+  requires: invocation_id
+  parameter_set: invocation_addressing
+  side_panel_name: Invocation Output
+
+invocation_time:
+  category: invocation
+  renders: Invocation run timestamp.
+  embeddable: true
+  requires: invocation_id
+  parameter_set: invocation_addressing
+  side_panel_name:
+    report: Time Workflow
+    page: Time a Workflow
+  side_panel_description: was invoked
+  help:
+    report: |
+      Display this workflow run's invocation time in the resulting document.
+    page: |
+      Display a workflow run's invocation time in the resulting document.
+
+workflow_display:
+  category: workflow
+  renders: Step-by-step text description of a workflow.
+  embeddable: false
+  requires: workflow_id
+  parameter_set: workflow_addressing
+  side_panel_name:
+    report: Current Workflow
+    page: Display a Workflow
+  side_panel_description: containing all steps
+  help:
+    report: |
+      Embed a text description of this workflow's steps in the resulting document.
+    page: |
+      Embed a text description of a workflow's steps in the resulting document.
+
+workflow_image:
+  category: workflow
+  renders: SVG workflow diagram.
+  embeddable: false
+  requires: workflow_id
+  parameter_set: workflow_addressing
+  parameters:
+    size:
+      type: enum
+      values: [sm, md, lg]
+      default: lg
+      description: Image width (sm=300px, md=550px, lg=100%).
+  side_panel_name: Workflow (as image)
+  help:
+    report: |
+      Embed a rough image this workflow in the resulting document.
+    page: |
+      Embed a rough image a workflow in the resulting document.
+
+workflow_license:
+  category: workflow
+  renders: Workflow license information.
+  embeddable: true
+  requires: workflow_id
+  parameters:
+    workflow_id:
+      type: id
+      context: page
+      description: Stored workflow ID.
+    invocation_id:
+      type: id
+      context: invocation
+      description: Invocation ID; usually injected automatically during resolution.
+  side_panel_name: Workflow License
+  help:
+    report: |
+      Display this workflow's license in the resulting document.
+    page: |
+      Display a workflow's license in the resulting document.
+
+job_metrics:
+  category: job
+  renders: Runtime metrics table for a job.
+  embeddable: false
+  requires: job_id
+  parameter_set: job_addressing
+  side_panel_name: Job Metrics
+  side_panel_description: as table
+  help: |
+    Embed the job metrics for this job in the resulting document (if Galaxy is configured and you have
+    permission).
+
+job_parameters:
+  category: job
+  renders: Tool parameters table for a job.
+  embeddable: false
+  requires: job_id
+  parameter_set: job_addressing
+  parameters:
+    footer:
+      type: string
+      description: Table footer.
+  side_panel_name: Job Parameters
+  side_panel_description: as table
+  help: |
+    Embed the tool parameters for a job in the resulting document.
+
+tool_stdout:
+  category: job
+  renders: Tool standard output for a job.
+  embeddable: false
+  requires: job_id
+  parameter_set: job_addressing
+  side_panel_name: Tool Output
+  side_panel_description: of job run
+  help: |
+    Embed the tool standard output stream for a job in the resulting document.
+
+tool_stderr:
+  category: job
+  renders: Tool standard error for a job.
+  embeddable: false
+  requires: job_id
+  parameter_set: job_addressing
+  side_panel_name: Tool Error
+  side_panel_description: of job run
+  help: |
+    Embed the tool standard error stream for a job in the resulting document.
+
+visualization:
+  category: visualization
+  renders: Galaxy plugin-based visualization.
+  embeddable: false
+  requires: history_dataset_id
+  dynamic_parameters: true
+  side_panel_name: Visualization
+  help: |
+    Embed a Galaxy visualization in the resulting document. Accepts arguments specific to the
+    selected visualization plugin; these arguments are not validated by the Galaxy Markdown parser.
+
+generate_time:
+  category: utility
+  renders: Current time at generation.
+  embeddable: true
+  requires: none
+  side_panel_name: Current Time
+  side_panel_description: as text
+  help: |
+    Report the current time of %MODE% generation.
+
+    Warning: This is the time the %MODE% was generated and not the time of
+    an analysis. This option makes the most sense for PDF generation of %MODE%s
+    designed for external archiving or printing.
+
+generate_galaxy_version:
+  category: utility
+  renders: Galaxy version string at generation.
+  embeddable: true
+  requires: none
+  side_panel_name: Galaxy Version
+  side_panel_description: as text
+  help: |
+    Report the current Galaxy version at the time %MODE% generation.
+
+    Warning: This is the Galaxy version at the time the %MODE% was generated and
+    not the time of an analysis. This option makes the most sense for PDF generation
+    of %MODE%s designed for external archiving or printing.
+
+instance_access_link:
+  category: utility
+  renders: Link to the Galaxy instance.
+  embeddable: true
+  requires: none
+  side_panel_name: Instance Access Link
+
+instance_resources_link:
+  category: utility
+  renders: Link to instance resources.
+  embeddable: true
+  requires: none
+  side_panel_name: Instance Resources Link
+
+instance_help_link:
+  category: utility
+  renders: Link to instance help.
+  embeddable: true
+  requires: none
+  side_panel_name: Instance Help Link
+
+instance_support_link:
+  category: utility
+  renders: Link to instance support.
+  embeddable: true
+  requires: none
+  side_panel_name: Instance Support Link
+
+instance_citation_link:
+  category: utility
+  renders: Link to instance citation information.
+  embeddable: true
+  requires: none
+  side_panel_name: Instance Citation Link
+
+instance_terms_link:
+  category: utility
+  renders: Link to instance terms.
+  embeddable: true
+  requires: none
+  side_panel_name: Instance Terms Link
+
+instance_organization_link:
+  category: utility
+  renders: Link to the instance's organization.
+  embeddable: true
+  requires: none
+  side_panel_name: Instance Organization Link

--- a/workflow-reports/SKILL.md
+++ b/workflow-reports/SKILL.md
@@ -163,7 +163,7 @@ One directive per fenced block. Never stack multiple directives in one block. Th
 
 Quotes are required when the value contains spaces.
 
-See `references/directives.md` for the full directive reference.
+See `references/directives.md` for the full directive reference (synced from upstream Galaxy via `make sync-directives`).
 
 ---
 

--- a/workflow-reports/references/directives.md
+++ b/workflow-reports/references/directives.md
@@ -1,6 +1,10 @@
 # Galaxy Markdown Directive Reference
 
-All directives must use **block syntax**. One directive per fenced block.
+Generated from `directives.yml` by `scripts/markdown_directives_doc.py` (`make client-gen-markdown-directives`). Do not edit by hand.
+
+## Syntax
+
+**Block** — works for every directive; required in workflow report templates:
 
 ````
 ```galaxy
@@ -8,111 +12,404 @@ directive_name(arg=value)
 ```
 ````
 
-The `${galaxy ...}` inline syntax does **not** work in workflow report templates.
+One directive per fenced `galaxy` block. **Inline** (`${galaxy ...}`) works only for the [embeddable directives](#embeddable-directives).
+
+## Argument value types
+
+| Type      | Meaning                                                             |
+| --------- | ------------------------------------------------------------------- |
+| `label`   | Workflow input/output/step label; resolved to an ID per invocation. |
+| `id`      | Encoded (export) or numeric (internal) object ID.                   |
+| `int`     | Integer.                                                            |
+| `boolean` | `true` or `false`.                                                  |
+| `enum`    | One of a fixed set of values.                                       |
+| `string`  | Free display text.                                                  |
+| `path`    | File within a composite / extra-files dataset.                      |
+
+## Addressing contexts
+
+The same directive accepts different parameters depending on how the object is referenced:
+
+| Context      | Use                                                       |
+| ------------ | --------------------------------------------------------- |
+| `report`     | Workflow report template — labels resolve per invocation. |
+| `page`       | Page / direct contexts — encoded or numeric IDs.          |
+| `notebook`   | History-relative reference (notebooks).                   |
+| `invocation` | Invocation reference — usually injected automatically.    |
+
+## Universal argument
+
+`collapse="<link text>"` — wraps a block directive in a collapsible section. Valid on every directive.
 
 ---
 
 ## Dataset directives
 
-Reference history items by workflow label (`input=`, `output=`) in templates, or by encoded ID (`history_dataset_id=`) in notebook/direct contexts.
+| Directive                  | Embed | Requires             | Renders                                                     |
+| -------------------------- | ----- | -------------------- | ----------------------------------------------------------- |
+| `history_dataset_display`  |       | `history_dataset_id` | Interactive dataset card with view/import/download options. |
+| `history_dataset_as_image` | ✅    | `history_dataset_id` | Dataset embedded as an image.                               |
+| `history_dataset_index`    |       | `history_dataset_id` | File/folder listing of a composite dataset.                 |
+| `history_dataset_embedded` |       | `history_dataset_id` | Raw dataset content inline.                                 |
+| `history_dataset_as_table` |       | `history_dataset_id` | Tabular dataset as a formatted table.                       |
+| `history_dataset_type`     | ✅    | `history_dataset_id` | Datatype string as text.                                    |
+| `history_dataset_link`     |       | `history_dataset_id` | Download link for a dataset.                                |
+| `history_dataset_name`     | ✅    | `history_dataset_id` | Dataset name as text.                                       |
+| `history_dataset_peek`     |       | `history_dataset_id` | Dataset "peek" preview.                                     |
+| `history_dataset_info`     |       | `history_dataset_id` | Dataset "info" metadata.                                    |
 
-| Directive | Renders | When to use |
-|-----------|---------|-------------|
-| `history_dataset_display` | Interactive dataset card | Default fallback for any dataset |
-| `history_dataset_as_image` | Embedded image | Plots, images, visual outputs — also works for collections |
-| `history_dataset_as_table` | Formatted table | Tabular results; supports `compact`, `title`, `footer`, `show_column_headers` |
-| `history_dataset_embedded` | Raw content | Small text or HTML outputs |
-| `history_dataset_link` | Download link | Inline download with custom `label` |
-| `history_dataset_peek` | First rows preview | Data snippets |
-| `history_dataset_info` | Dataset metadata | Tool output metadata |
-| `history_dataset_name` | Dataset name text | References in prose |
-| `history_dataset_type` | Datatype string | References in prose |
-| `history_dataset_index` | Composite file listing | Multi-file composite datasets |
-| `history_dataset_collection_display` | Collection browser | Paired/list collections |
+### `history_dataset_display`
 
-### Parameters
+Display a dataset and relevant options for viewing, importing, downloading,
+and visualization in the resulting document. To embed a dataset directly
+into the document use the "history_dataset_embedded" / "Embedded Dataset"
+directive.
 
-```
-history_dataset_as_table(
-  output=           # workflow output label (in templates)
-  input=            # workflow input label (in templates)
-  history_dataset_id=   # encoded ID (in notebooks)
-  title=            # table title
-  footer=           # table footer
-  compact=          # true/false — compact row height
-  show_column_headers=  # true/false
-  collapse=         # collapsible section label
-)
+| Parameter            | Type    | Context      | Default | Description                                                        |
+| -------------------- | ------- | ------------ | ------- | ------------------------------------------------------------------ |
+| `output`             | `label` | `report`     |         | Workflow output label, resolved per invocation (report templates). |
+| `input`              | `label` | `report`     |         | Workflow input label, resolved per invocation (report templates).  |
+| `hid`                | `int`   | `notebook`   |         | History item hid.                                                  |
+| `history_dataset_id` | `id`    | `page`       |         | Encoded (export) or numeric (internal) dataset ID.                 |
+| `invocation_id`      | `id`    | `invocation` |         | Invocation ID; usually injected automatically during resolution.   |
 
-history_dataset_as_image(
-  output=
-  input=
-  history_dataset_id=
-  collapse=
-)
+### `history_dataset_as_image`
 
-history_dataset_link(
-  output=
-  input=
-  history_dataset_id=
-  label=            # link text
-)
-```
+Embed a dataset in the resulting document as an image. This only works for simple image
+types. This can be used to present graphs and other visual summaries of an analysis into
+a Galaxy Markdown document summary.
+
+| Parameter            | Type    | Context      | Default | Description                                                        |
+| -------------------- | ------- | ------------ | ------- | ------------------------------------------------------------------ |
+| `output`             | `label` | `report`     |         | Workflow output label, resolved per invocation (report templates). |
+| `input`              | `label` | `report`     |         | Workflow input label, resolved per invocation (report templates).  |
+| `hid`                | `int`   | `notebook`   |         | History item hid.                                                  |
+| `history_dataset_id` | `id`    | `page`       |         | Encoded (export) or numeric (internal) dataset ID.                 |
+| `invocation_id`      | `id`    | `invocation` |         | Invocation ID; usually injected automatically during resolution.   |
+| `path`               | `path`  |              |         | File within a composite / extra-files dataset.                     |
+
+### `history_dataset_index`
+
+For Galaxy composite datasets (datasets that consist on multiple files), this option will
+display the contents of the composite dataset as files and folders in the resulting document.
+
+| Parameter            | Type    | Context      | Default | Description                                                        |
+| -------------------- | ------- | ------------ | ------- | ------------------------------------------------------------------ |
+| `output`             | `label` | `report`     |         | Workflow output label, resolved per invocation (report templates). |
+| `input`              | `label` | `report`     |         | Workflow input label, resolved per invocation (report templates).  |
+| `hid`                | `int`   | `notebook`   |         | History item hid.                                                  |
+| `history_dataset_id` | `id`    | `page`       |         | Encoded (export) or numeric (internal) dataset ID.                 |
+| `invocation_id`      | `id`    | `invocation` |         | Invocation ID; usually injected automatically during resolution.   |
+| `path`               | `path`  |              |         | File within a composite / extra-files dataset.                     |
+
+### `history_dataset_embedded`
+
+| Parameter            | Type    | Context      | Default | Description                                                        |
+| -------------------- | ------- | ------------ | ------- | ------------------------------------------------------------------ |
+| `output`             | `label` | `report`     |         | Workflow output label, resolved per invocation (report templates). |
+| `input`              | `label` | `report`     |         | Workflow input label, resolved per invocation (report templates).  |
+| `hid`                | `int`   | `notebook`   |         | History item hid.                                                  |
+| `history_dataset_id` | `id`    | `page`       |         | Encoded (export) or numeric (internal) dataset ID.                 |
+| `invocation_id`      | `id`    | `invocation` |         | Invocation ID; usually injected automatically during resolution.   |
+
+### `history_dataset_as_table`
+
+Embed a dataset in the resulting document as a table. This only works for datasets with tabular
+datatypes. This command works a lot like "history_dataset_embedded" but provides specialized options
+for controlling the way tabular data is displayed in the resulting document.
+
+| Parameter             | Type      | Context      | Default | Description                                                        |
+| --------------------- | --------- | ------------ | ------- | ------------------------------------------------------------------ |
+| `output`              | `label`   | `report`     |         | Workflow output label, resolved per invocation (report templates). |
+| `input`               | `label`   | `report`     |         | Workflow input label, resolved per invocation (report templates).  |
+| `hid`                 | `int`     | `notebook`   |         | History item hid.                                                  |
+| `history_dataset_id`  | `id`      | `page`       |         | Encoded (export) or numeric (internal) dataset ID.                 |
+| `invocation_id`       | `id`      | `invocation` |         | Invocation ID; usually injected automatically during resolution.   |
+| `title`               | `string`  |              |         | Table title.                                                       |
+| `footer`              | `string`  |              |         | Table footer.                                                      |
+| `compact`             | `boolean` |              | `false` | Compact row height.                                                |
+| `show_column_headers` | `boolean` |              | `true`  | Show column headers.                                               |
+| `path`                | `path`    |              |         | File within a composite / extra-files dataset.                     |
+
+### `history_dataset_type`
+
+| Parameter            | Type    | Context      | Default | Description                                                        |
+| -------------------- | ------- | ------------ | ------- | ------------------------------------------------------------------ |
+| `output`             | `label` | `report`     |         | Workflow output label, resolved per invocation (report templates). |
+| `input`              | `label` | `report`     |         | Workflow input label, resolved per invocation (report templates).  |
+| `hid`                | `int`   | `notebook`   |         | History item hid.                                                  |
+| `history_dataset_id` | `id`    | `page`       |         | Encoded (export) or numeric (internal) dataset ID.                 |
+| `invocation_id`      | `id`    | `invocation` |         | Invocation ID; usually injected automatically during resolution.   |
+
+### `history_dataset_link`
+
+| Parameter            | Type     | Context      | Default | Description                                                        |
+| -------------------- | -------- | ------------ | ------- | ------------------------------------------------------------------ |
+| `output`             | `label`  | `report`     |         | Workflow output label, resolved per invocation (report templates). |
+| `input`              | `label`  | `report`     |         | Workflow input label, resolved per invocation (report templates).  |
+| `hid`                | `int`    | `notebook`   |         | History item hid.                                                  |
+| `history_dataset_id` | `id`     | `page`       |         | Encoded (export) or numeric (internal) dataset ID.                 |
+| `invocation_id`      | `id`     | `invocation` |         | Invocation ID; usually injected automatically during resolution.   |
+| `label`              | `string` |              |         | Link text.                                                         |
+| `path`               | `path`   |              |         | File within a composite / extra-files dataset.                     |
+
+### `history_dataset_name`
+
+| Parameter            | Type    | Context      | Default | Description                                                        |
+| -------------------- | ------- | ------------ | ------- | ------------------------------------------------------------------ |
+| `output`             | `label` | `report`     |         | Workflow output label, resolved per invocation (report templates). |
+| `input`              | `label` | `report`     |         | Workflow input label, resolved per invocation (report templates).  |
+| `hid`                | `int`   | `notebook`   |         | History item hid.                                                  |
+| `history_dataset_id` | `id`    | `page`       |         | Encoded (export) or numeric (internal) dataset ID.                 |
+| `invocation_id`      | `id`    | `invocation` |         | Invocation ID; usually injected automatically during resolution.   |
+
+### `history_dataset_peek`
+
+Display a dataset metadata's "peek" field in the resulting document - this is datatype dependent
+metadata but usually this is a few lines from the start of a file.
+
+| Parameter            | Type    | Context      | Default | Description                                                        |
+| -------------------- | ------- | ------------ | ------- | ------------------------------------------------------------------ |
+| `output`             | `label` | `report`     |         | Workflow output label, resolved per invocation (report templates). |
+| `input`              | `label` | `report`     |         | Workflow input label, resolved per invocation (report templates).  |
+| `hid`                | `int`   | `notebook`   |         | History item hid.                                                  |
+| `history_dataset_id` | `id`    | `page`       |         | Encoded (export) or numeric (internal) dataset ID.                 |
+| `invocation_id`      | `id`    | `invocation` |         | Invocation ID; usually injected automatically during resolution.   |
+
+### `history_dataset_info`
+
+Display a dataset metadata's "info" field in the resulting document. This info field is
+usually based on the output of the tool run and sometimes contains useful metadata about a
+dataset.
+
+| Parameter            | Type    | Context      | Default | Description                                                        |
+| -------------------- | ------- | ------------ | ------- | ------------------------------------------------------------------ |
+| `output`             | `label` | `report`     |         | Workflow output label, resolved per invocation (report templates). |
+| `input`              | `label` | `report`     |         | Workflow input label, resolved per invocation (report templates).  |
+| `hid`                | `int`   | `notebook`   |         | History item hid.                                                  |
+| `history_dataset_id` | `id`    | `page`       |         | Encoded (export) or numeric (internal) dataset ID.                 |
+| `invocation_id`      | `id`    | `invocation` |         | Invocation ID; usually injected automatically during resolution.   |
+
+---
+
+## Collection directives
+
+| Directive                            | Embed | Requires                        | Renders                                         |
+| ------------------------------------ | ----- | ------------------------------- | ----------------------------------------------- |
+| `history_dataset_collection_display` |       | `history_dataset_collection_id` | Collection browser for paired/list collections. |
+
+### `history_dataset_collection_display`
+
+Display a dataset collection and relevant options for viewing, importing, downloading
+in the resulting document.
+
+| Parameter                       | Type    | Context      | Default | Description                                                        |
+| ------------------------------- | ------- | ------------ | ------- | ------------------------------------------------------------------ |
+| `output`                        | `label` | `report`     |         | Workflow output label, resolved per invocation (report templates). |
+| `input`                         | `label` | `report`     |         | Workflow input label, resolved per invocation (report templates).  |
+| `hid`                           | `int`   | `notebook`   |         | History item hid.                                                  |
+| `history_dataset_collection_id` | `id`    | `page`       |         | Encoded or numeric dataset collection ID.                          |
+| `invocation_id`                 | `id`    | `invocation` |         | Invocation ID; usually injected automatically during resolution.   |
 
 ---
 
 ## Invocation directives
 
-| Directive | Renders | When to use |
-|-----------|---------|-------------|
-| `invocation_inputs()` | All workflow inputs | Summary of submitted inputs |
-| `invocation_outputs()` | All workflow outputs | Summary of all outputs |
-| `invocation_time()` | Run timestamp | Always include at top of report |
-| `history_link()` | History import link | Always include in Reproducibility section |
+| Directive            | Embed | Requires        | Renders                                |
+| -------------------- | ----- | --------------- | -------------------------------------- |
+| `history_link`       |       | `history_id`    | Link to import the referenced history. |
+| `invocation_inputs`  |       | `invocation_id` | Summary of all workflow inputs.        |
+| `invocation_outputs` |       | `invocation_id` | Summary of all workflow outputs.       |
+| `invocation_time`    | ✅    | `invocation_id` | Invocation run timestamp.              |
 
----
+### `history_link`
 
-## Job directives
+Add a link to import the history the workflow invocation was executed in.
 
-Use `step="<step label>"` in workflow templates. Step label must match exactly.
+| Parameter       | Type | Context      | Default | Description                                                      |
+| --------------- | ---- | ------------ | ------- | ---------------------------------------------------------------- |
+| `history_id`    | `id` | `page`       |         | Encoded or numeric history ID.                                   |
+| `invocation_id` | `id` | `invocation` |         | Invocation ID; usually injected automatically during resolution. |
 
-| Directive | Renders | When to use |
-|-----------|---------|-------------|
-| `job_parameters(step=, collapse=)` | Tool parameters table | Key analytical steps |
-| `job_metrics(step=, collapse=)` | Runtime metrics | Performance documentation |
-| `tool_stdout(step=)` | Tool standard output | Capturing logs |
-| `tool_stderr(step=)` | Tool standard error | Capturing warnings |
+### `invocation_inputs`
+
+| Parameter       | Type | Context      | Default | Description                                                      |
+| --------------- | ---- | ------------ | ------- | ---------------------------------------------------------------- |
+| `invocation_id` | `id` | `invocation` |         | Invocation ID; usually injected automatically during resolution. |
+
+### `invocation_outputs`
+
+| Parameter       | Type | Context      | Default | Description                                                      |
+| --------------- | ---- | ------------ | ------- | ---------------------------------------------------------------- |
+| `invocation_id` | `id` | `invocation` |         | Invocation ID; usually injected automatically during resolution. |
+
+### `invocation_time`
+
+Display this workflow run's invocation time in the resulting document.
+
+| Parameter       | Type | Context      | Default | Description                                                      |
+| --------------- | ---- | ------------ | ------- | ---------------------------------------------------------------- |
+| `invocation_id` | `id` | `invocation` |         | Invocation ID; usually injected automatically during resolution. |
 
 ---
 
 ## Workflow directives
 
-| Directive | Renders | When to use |
-|-----------|---------|-------------|
-| `workflow_image()` | SVG workflow diagram | Always include in Summary section |
-| `workflow_display(collapse=)` | Step-by-step breakdown | Optional, usually collapsible |
-| `workflow_license()` | License info | Attribution / reproducibility |
+| Directive          | Embed | Requires      | Renders                                      |
+| ------------------ | ----- | ------------- | -------------------------------------------- |
+| `workflow_display` |       | `workflow_id` | Step-by-step text description of a workflow. |
+| `workflow_image`   |       | `workflow_id` | SVG workflow diagram.                        |
+| `workflow_license` | ✅    | `workflow_id` | Workflow license information.                |
+
+### `workflow_display`
+
+Embed a text description of this workflow's steps in the resulting document.
+
+| Parameter             | Type  | Context      | Default | Description                                                      |
+| --------------------- | ----- | ------------ | ------- | ---------------------------------------------------------------- |
+| `workflow_id`         | `id`  | `page`       |         | Stored workflow ID.                                              |
+| `workflow_checkpoint` | `int` | `page`       |         | Workflow version index.                                          |
+| `invocation_id`       | `id`  | `invocation` |         | Invocation ID; usually injected automatically during resolution. |
+
+### `workflow_image`
+
+Embed a rough image this workflow in the resulting document.
+
+| Parameter             | Type                    | Context      | Default | Description                                                      |
+| --------------------- | ----------------------- | ------------ | ------- | ---------------------------------------------------------------- |
+| `workflow_id`         | `id`                    | `page`       |         | Stored workflow ID.                                              |
+| `workflow_checkpoint` | `int`                   | `page`       |         | Workflow version index.                                          |
+| `invocation_id`       | `id`                    | `invocation` |         | Invocation ID; usually injected automatically during resolution. |
+| `size`                | enum (`sm`, `md`, `lg`) |              | `lg`    | Image width (sm=300px, md=550px, lg=100%).                       |
+
+### `workflow_license`
+
+Display this workflow's license in the resulting document.
+
+| Parameter       | Type | Context      | Default | Description                                                      |
+| --------------- | ---- | ------------ | ------- | ---------------------------------------------------------------- |
+| `workflow_id`   | `id` | `page`       |         | Stored workflow ID.                                              |
+| `invocation_id` | `id` | `invocation` |         | Invocation ID; usually injected automatically during resolution. |
 
 ---
 
-## Utility directives
+## Job directives
 
-| Directive | Renders |
-|-----------|---------|
-| `generate_time()` | Current timestamp |
-| `generate_galaxy_version()` | Galaxy version string |
-| `instance_access_link()` | Link to Galaxy instance |
-| `instance_citation_link()` | Citation info |
-| `instance_help_link()` | Help link |
+| Directive        | Embed | Requires | Renders                          |
+| ---------------- | ----- | -------- | -------------------------------- |
+| `job_metrics`    |       | `job_id` | Runtime metrics table for a job. |
+| `job_parameters` |       | `job_id` | Tool parameters table for a job. |
+| `tool_stdout`    |       | `job_id` | Tool standard output for a job.  |
+| `tool_stderr`    |       | `job_id` | Tool standard error for a job.   |
+
+### `job_metrics`
+
+Embed the job metrics for this job in the resulting document (if Galaxy is configured and you have
+permission).
+
+| Parameter                     | Type    | Context      | Default | Description                                                      |
+| ----------------------------- | ------- | ------------ | ------- | ---------------------------------------------------------------- |
+| `step`                        | `label` | `report`     |         | Workflow step label, resolved per invocation (report templates). |
+| `job_id`                      | `id`    | `page`       |         | Encoded or numeric job ID.                                       |
+| `implicit_collection_jobs_id` | `id`    | `page`       |         | Mapped-collection job group ID.                                  |
+| `invocation_id`               | `id`    | `invocation` |         | Invocation ID; usually injected automatically during resolution. |
+
+### `job_parameters`
+
+Embed the tool parameters for a job in the resulting document.
+
+| Parameter                     | Type     | Context      | Default | Description                                                      |
+| ----------------------------- | -------- | ------------ | ------- | ---------------------------------------------------------------- |
+| `step`                        | `label`  | `report`     |         | Workflow step label, resolved per invocation (report templates). |
+| `job_id`                      | `id`     | `page`       |         | Encoded or numeric job ID.                                       |
+| `implicit_collection_jobs_id` | `id`     | `page`       |         | Mapped-collection job group ID.                                  |
+| `invocation_id`               | `id`     | `invocation` |         | Invocation ID; usually injected automatically during resolution. |
+| `footer`                      | `string` |              |         | Table footer.                                                    |
+
+### `tool_stdout`
+
+Embed the tool standard output stream for a job in the resulting document.
+
+| Parameter                     | Type    | Context      | Default | Description                                                      |
+| ----------------------------- | ------- | ------------ | ------- | ---------------------------------------------------------------- |
+| `step`                        | `label` | `report`     |         | Workflow step label, resolved per invocation (report templates). |
+| `job_id`                      | `id`    | `page`       |         | Encoded or numeric job ID.                                       |
+| `implicit_collection_jobs_id` | `id`    | `page`       |         | Mapped-collection job group ID.                                  |
+| `invocation_id`               | `id`    | `invocation` |         | Invocation ID; usually injected automatically during resolution. |
+
+### `tool_stderr`
+
+Embed the tool standard error stream for a job in the resulting document.
+
+| Parameter                     | Type    | Context      | Default | Description                                                      |
+| ----------------------------- | ------- | ------------ | ------- | ---------------------------------------------------------------- |
+| `step`                        | `label` | `report`     |         | Workflow step label, resolved per invocation (report templates). |
+| `job_id`                      | `id`    | `page`       |         | Encoded or numeric job ID.                                       |
+| `implicit_collection_jobs_id` | `id`    | `page`       |         | Mapped-collection job group ID.                                  |
+| `invocation_id`               | `id`    | `invocation` |         | Invocation ID; usually injected automatically during resolution. |
 
 ---
 
-## Universal argument
+## Visualization directive
 
-`collapse="<link text>"` — wraps any block directive in a collapsible section.
+| Directive       | Embed | Requires             | Renders                            |
+| --------------- | ----- | -------------------- | ---------------------------------- |
+| `visualization` |       | `history_dataset_id` | Galaxy plugin-based visualization. |
 
-````
-```galaxy
-job_parameters(step="Alignment", collapse="Show alignment parameters")
-```
-````
+### `visualization`
+
+Embed a Galaxy visualization in the resulting document. Accepts arguments specific to the
+selected visualization plugin; these arguments are not validated by the Galaxy Markdown parser.
+
+---
+
+## Utility & instance directives
+
+| Directive                    | Embed | Requires | Renders                                |
+| ---------------------------- | ----- | -------- | -------------------------------------- |
+| `generate_time`              | ✅    | —        | Current time at generation.            |
+| `generate_galaxy_version`    | ✅    | —        | Galaxy version string at generation.   |
+| `instance_access_link`       | ✅    | —        | Link to the Galaxy instance.           |
+| `instance_resources_link`    | ✅    | —        | Link to instance resources.            |
+| `instance_help_link`         | ✅    | —        | Link to instance help.                 |
+| `instance_support_link`      | ✅    | —        | Link to instance support.              |
+| `instance_citation_link`     | ✅    | —        | Link to instance citation information. |
+| `instance_terms_link`        | ✅    | —        | Link to instance terms.                |
+| `instance_organization_link` | ✅    | —        | Link to the instance's organization.   |
+
+### `generate_time`
+
+Report the current time of report generation.
+
+Warning: This is the time the report was generated and not the time of
+an analysis. This option makes the most sense for PDF generation of reports
+designed for external archiving or printing.
+
+### `generate_galaxy_version`
+
+Report the current Galaxy version at the time report generation.
+
+Warning: This is the Galaxy version at the time the report was generated and
+not the time of an analysis. This option makes the most sense for PDF generation
+of reports designed for external archiving or printing.
+
+---
+
+## Embeddable directives
+
+Inline `${galaxy ...}` syntax is supported only for these directives; all others require block syntax.
+
+- `history_dataset_as_image`
+- `history_dataset_type`
+- `history_dataset_name`
+- `invocation_time`
+- `workflow_license`
+- `generate_time`
+- `generate_galaxy_version`
+- `instance_access_link`
+- `instance_resources_link`
+- `instance_help_link`
+- `instance_support_link`
+- `instance_citation_link`
+- `instance_terms_link`
+- `instance_organization_link`


### PR DESCRIPTION
## What

Adds a new **`reproduciblify`** skill and a `Makefile` that vendors Galaxy's
Markdown directive reference from upstream Galaxy into the skills that need it.

### `reproduciblify` skill

Takes a real (often messy) Galaxy history — manual uploads of derived data,
pasted figures, off-graph scratch steps, one-sample-at-a-time structure — and
rebuilds it so its entire computational closure lives on the Galaxy provenance
graph, then authors a Galaxy Notebook that extracts cleanly into a reusable,
sample-agnostic workflow. Core moves:

- Replace every off-graph computation with an on-graph tool (find a superior
  existing tool; create one via `tool-dev` only as a fallback).
- Restructure for arbitrary arity with collections (map-over, nested
  `list:list`, split irreducible pairwise comparisons into producer + comparator).
- Embed only genuine on-graph tool outputs as notebook directives, since those
  are the artifacts workflow extraction can walk back from.

### Directive reference sync (`make sync-directives`)

Galaxy's `client/src/components/Markdown/directives.{yml,md}` are the source of
truth for the markdown directive catalog. The Makefile fetches them from
`galaxyproject/galaxy` and vendors **one form per skill** (no duplicated content
loaded into either skill's context):

- `workflow-reports/references/directives.md` — human-readable Markdown.
- `reproduciblify/references/directives.yml` — machine-readable YAML.

Override the source to pull from an unmerged branch:
`make sync-directives GALAXY_REPO=jmchilton/galaxy GALAXY_REF=directives`

> Depends on the Galaxy `directives` branch being merged before
> `make sync-directives` works against the default `dev` ref.

### Note for @ahmedhamidawan

This replaces the previously hand-written `workflow-reports/references/directives.md`
(~118 lines) with the upstream auto-generated reference (~415 lines, marked
"do not edit by hand"). The `workflow-reports` skill text is unchanged except a
pointer to `make sync-directives`. Re-sync rather than hand-editing going forward.

## Testing

- `make sync-directives GALAXY_REPO=jmchilton/galaxy GALAXY_REF=directives`
  fetches `directives.md` -> `workflow-reports/references/` and `directives.yml`
  -> `reproduciblify/references/`, and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
