### PR TITLE
Add udt-authoring skill for Galaxy User-Defined Tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,20 @@ If the user asks to create, draft, or write a Galaxy workflow report template fo
   - `workflow-reports/examples/histology-staining.md` (worked example: imaging quantification)
   - `workflow-reports/examples/tissue-microarray-analysis.md` (worked example: multiplex tissue analysis)
 
+## User-Defined Tools (UDTs)
+
+If the user asks to create a tool they (a non-admin) can define and run in their own Galaxy account — the `class: GalaxyUserTool` YAML format, often created/run via Galaxy MCP `create_user_tool` / `run_user_tool` or `POST /api/unprivileged_tools` — use the udt-authoring skill. This is distinct from classic XML/ToolShed wrappers (use `tool-dev` for those).
+
+- Skill:
+  - `udt-authoring/SKILL.md`
+
+- References:
+  - `udt-authoring/references/schema-reference.md` (UserToolSource fields, input/output types, validators)
+  - `udt-authoring/references/templating.md` (`$(...)` ECMAScript, `$GALAXY_SLOTS`, escaping)
+  - `udt-authoring/references/common-mistakes.md` (pre-submit self-review checklist)
+  - `udt-authoring/scripts/validate.py` (offline validate + lint via galaxy-tool-util)
+  - `udt-authoring/examples/` (seven complete UDTs, simple to complex)
+
 ## Other skills in this repo
 
 If the user asks about one of these tasks, use the corresponding skill:
@@ -88,5 +102,6 @@ If the user asks about one of these tasks, use the corresponding skill:
 - `hub-news-posts/SKILL.md` (Galaxy Hub news posts)
 - `tool-dev/SKILL.md` (comprehensive Galaxy tool development reference)
   - `tool-dev/tool-selection-diagram/SKILL.md` (generate tool selection flowchart diagrams)
+- `udt-authoring/SKILL.md` (author User-Defined Tools — GalaxyUserTool YAML)
 
 For general discovery of what's available, start at `README.md`.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,15 @@ Create and update Galaxy tool wrappers.
 - **references/** - Standalone testing and tool placement guides (also used by other skills)
 - **tool-selection-diagram/** - Generate "which tool?" flowchart PNGs for multi-tool suites
 
+**udt-authoring** ✅
+
+Author Galaxy User-Defined Tools (UDTs) — the `class: GalaxyUserTool` YAML format a non-admin user creates and runs (distinct from classic XML/ToolShed wrappers).
+
+- SKILL.md with the authoring loop and offline/server validation tiers
+- **references/** - UserToolSource schema, `$(...)` templating, common mistakes checklist
+- **scripts/validate.py** - offline validate + lint via galaxy-tool-util
+- **examples/** - seven complete UDTs, simple to complex
+
 ### Content
 
 **hub-news-posts** ✅
@@ -155,6 +164,12 @@ skills/
 │   ├── SKILL.md                # Comprehensive tool dev reference
 │   ├── references/             # Testing, tool placement guides
 │   └── tool-selection-diagram/ # Flowchart diagram generator for multi-tool suites
+│
+├── udt-authoring/               # ✅ Author User-Defined Tools (GalaxyUserTool YAML)
+│   ├── SKILL.md                 # Authoring loop + validation tiers
+│   ├── references/              # Schema, templating, common mistakes
+│   ├── scripts/                 # validate.py (offline validate + lint)
+│   └── examples/                # Seven complete UDTs
 │
 ├── hub-news-posts/              # ✅ Galaxy Hub posts
 │

--- a/udt-authoring/SKILL.md
+++ b/udt-authoring/SKILL.md
@@ -110,8 +110,11 @@ check offline before submitting. Three tiers, weakest to strongest:
 1. **Local** (fast, offline, side-effect-free): `python scripts/validate.py my-tool.yml`. Needs
    `pip install galaxy-tool-util`. Catches structural errors, the four semantic validators, and
    lint warnings. Use this whenever a Python env is available (terminal, CI). See `scripts/`.
-2. **`planemo lint`** -- not available yet (planemo does not lint UDTs as of this writing); will be
-   the preferred ergonomic check once it lands.
+2. **`planemo lint`** -- not available yet (planemo does not lint UDTs as of this writing). It
+   already depends on `galaxy-tool-util`, so teaching it to lint a `GalaxyUserTool` YAML would be a
+   small addition, and it's the natural future home for tier 1. Down the road `scripts/validate.py`
+   should migrate to `planemo lint <tool>.yml`, so authors get this check through the standard Galaxy
+   tool CLI instead of a bundled script. Until that lands, use tier 1.
 3. **Server create** -- `create_user_tool` / `POST /api/unprivileged_tools` runs the same lint and
    confirms *this server* accepts it (needs `enable_beta_tool_formats` + the Custom Tool Execution
    role). This is the final word, and the practical gate for environments without Python (e.g.

--- a/udt-authoring/SKILL.md
+++ b/udt-authoring/SKILL.md
@@ -78,7 +78,8 @@ Templating syntax (`$(inputs.x)`, arrays, `$GALAXY_SLOTS`, escaping): **`referen
    below. Lint will *not* catch a bad image; the job simply fails to pull it.
 3. **Draft the definition** using `references/schema-reference.md`. Reference each input as
    `$(inputs.name.path)` (data) or `$(inputs.name)` (scalar). Write outputs to fixed filenames and
-   claim them with `from_work_dir` / `discover_datasets`.
+   claim them with `from_work_dir` / `discover_datasets`. Always include a `help` block (convention
+   -- see "Write a help block" below).
 4. **Self-review** against `references/common-mistakes.md` (it doubles as a checklist).
 5. **Validate** (see below) and iterate on real errors.
 6. **Create + run.** Hand the validated definition to `create_user_tool`, then `run_user_tool`
@@ -101,6 +102,33 @@ on quay. Guard against it:
   switch to `python:3.11-slim` and emit SVG with the standard library, no third-party image to get
   wrong.
 - **Never invent an image, tag, or CLI flag you can't verify** -- ask the user rather than guessing.
+
+## Write a `help` block (convention)
+
+`help` is schema-optional, but **always include a real one**. Galaxy renders it under the parameter
+form on the tool page, so a UDT without help is a black box to anyone -- including the same user
+weeks later -- who opens it. The wire shape is an object, not a bare string:
+
+```yaml
+help:
+  format: markdown        # markdown | restructuredtext | plain_text
+  content: |
+    Cuts a single column from a tab-separated file.
+
+    **Inputs**
+    - `input`: TSV file (with or without header).
+    - `column`: 1-based column index.
+
+    **Outputs**
+    - `output`: TSV with only the selected column, in input row order.
+
+    Header lines are not auto-detected; the column index applies to every row.
+```
+
+Three short paragraphs is enough: what the tool does, its inputs/outputs, and any caveat (resource
+limits, expected file shape, non-obvious behavior). Don't ship a `TODO` placeholder -- an empty or
+stub `help` is no better than none. If help genuinely isn't worth writing (a one-off throwaway), say
+so and confirm with the user before creating the tool.
 
 ## Validating a Definition
 
@@ -125,6 +153,13 @@ check offline before submitting. Three tiers, weakest to strongest:
 > Those only surface when the job runs. A nonexistent container tag (`manifest unknown` at run
 > time) is the most common real-world UDT failure, so verify the image (see "Choosing a Container")
 > before relying on a clean validation.
+
+## Iterating & Cleanup
+
+There is no in-place update API -- every `create_user_tool` call makes a **new** tool. When you
+iterate, bump `version` (e.g. `0.1.0` -> `0.2.0`); Galaxy keeps every prior version under the user's
+account. Heavy iteration accumulates stale versions, so once a design stabilizes, offer to remove the
+superseded ones with `delete_user_tool`.
 
 ## Common Patterns
 
@@ -151,6 +186,8 @@ See `examples/` for seven complete, validated UDTs spanning these patterns.
 | `string_pattern_mismatch` on `id` | Uppercase, leading digit, spaces | Use `^[a-z][a-z0-9_-]*$` |
 | extra-field rejection | XML-ism like `truevalue`, `command`, `${on_string}` | Remove it -- schema is `extra="forbid"` |
 | `manifest unknown` / `Unable to find image` at **run** time | Container tag doesn't exist on the registry | Use a real, verified tag (or `python:3.x-slim` for stdlib tools) -- lint can't catch this |
+| HTTP 403 "not allowed to run unprivileged" | The admin's job routing (TPV) rejects `tool_type_user_defined` by default | Not fixable client-side -- the admin must add a destination/routing rule for user-defined tools |
+| HTTP 400 on `help` | `help` sent as a bare string | Use the object form: `help: {format, content}` |
 
 Full list with the why behind each: `references/common-mistakes.md`.
 

--- a/udt-authoring/SKILL.md
+++ b/udt-authoring/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: udt-authoring
-description: Use when authoring a Galaxy User-Defined Tool (UDT) -- a `class: GalaxyUserTool` YAML definition that wraps a container and command into a tool a non-admin user creates and runs (e.g. via Galaxy MCP create_user_tool / run_user_tool, or POST /api/unprivileged_tools). Not for classic XML/ToolShed tool wrappers.
+description: "Use when authoring a Galaxy User-Defined Tool (UDT) -- a `class: GalaxyUserTool` YAML definition that wraps a container and command into a tool a non-admin user creates and runs (e.g. via Galaxy MCP create_user_tool / run_user_tool, or POST /api/unprivileged_tools). Not for classic XML/ToolShed tool wrappers."
+metadata:
+  surfaces: [loom]
 version: 1.0.0
 tags: [galaxy, tools, udt, user-defined-tools, custom-tool]
 ---

--- a/udt-authoring/SKILL.md
+++ b/udt-authoring/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: udt-authoring
+description: Use when authoring a Galaxy User-Defined Tool (UDT) -- a `class: GalaxyUserTool` YAML definition that wraps a container and command into a tool a non-admin user creates and runs (e.g. via Galaxy MCP create_user_tool / run_user_tool, or POST /api/unprivileged_tools). Not for classic XML/ToolShed tool wrappers.
+version: 1.0.0
+tags: [galaxy, tools, udt, user-defined-tools, custom-tool]
+---
+
+# Authoring Galaxy User-Defined Tools (UDTs)
+
+A **User-Defined Tool (UDT)** is a tool that a regular (non-admin) Galaxy user defines in YAML
+and runs unprivileged, introduced in Galaxy 25.0. It is declared with `class: GalaxyUserTool` and
+validated against the `UserToolSource` schema. This skill is the reference for producing a correct,
+lint-clean definition.
+
+## When to Use
+
+- The user wants to wrap a command + container as a runnable Galaxy tool they own.
+- Triggers: "make me a Galaxy tool that runs X", "wrap this command as a UDT", "create a custom
+  tool", "register a tool in my account".
+- You are an external agent (Loom, an MCP client, a notebook) that will create/run the tool via
+  `create_user_tool` / `run_user_tool` or `POST /api/unprivileged_tools`.
+
+**When NOT to use:** classic XML / ToolShed tool wrappers (Cheetah templating, `tools-iuc`
+submission) -- that is a different format; use the `tool-dev` skill instead. A UDT is **not** XML
+and does **not** use Cheetah.
+
+## Mental Model (read this first -- it is where agents go wrong)
+
+A UDT = a **container** + a **`shell_command`** + typed **`inputs`** and **`outputs`**.
+
+- The command lives under **`shell_command`** (NOT `command`).
+- Parameters are interpolated with **sandboxed ECMAScript inside `$(...)`** -- NOT Cheetah `$x` and
+  NOT `#for#` loops. A data file's path is `$(inputs.name.path)`; a scalar value is
+  `$(inputs.name)`.
+- The sandbox has **no database, filesystem, or network access**. Every UDT **must run in a
+  container** (`container:` is a required plain string).
+- Every output must **claim a file** it produced via `from_work_dir` (one file) or
+  `discover_datasets` (many) -- you do not write to a templated output path.
+
+If you find yourself writing `command:`, `$param`, `#for#`, `truevalue:`, or `${on_string}`, stop
+-- those are XML/Cheetah habits the schema rejects. See `references/common-mistakes.md`.
+
+## Quick Reference -- minimal valid skeleton
+
+```yaml
+class: GalaxyUserTool          # required, exactly this
+id: my-tool                    # lowercase, ^[a-z][a-z0-9_-]*$, 3-255 chars (recommended)
+version: "0.1.0"               # recommended
+name: My Tool                  # required, min 5 chars
+description: One line shown in the tool menu
+container: quay.io/biocontainers/seqkit:2.8.2--h9ee0642_0   # required STRING, a real image
+shell_command: |
+  seqkit stats --tabular '$(inputs.input.path)' > stats.tsv
+inputs:
+  - name: input
+    type: data
+    format: fastq
+    label: Input sequences
+outputs:
+  - name: report
+    type: data
+    format: tabular
+    from_work_dir: stats.tsv        # claim the file the command wrote
+    label: Sequence statistics
+```
+
+Full field list, input/output types, and validator rules: **`references/schema-reference.md`**.
+Templating syntax (`$(inputs.x)`, arrays, `$GALAXY_SLOTS`, escaping): **`references/templating.md`**.
+
+## Authoring Workflow
+
+1. **Understand the command.** What binary runs, what inputs it consumes, what files it produces.
+2. **Pick a real container** -- this is the #1 cause of runtime failure. Prefer a verified
+   biocontainer (`quay.io/biocontainers/<tool>:<tag>`), but **never guess the `--<hash>_<build>`
+   tag suffix** -- it is not predictable. Look up the real tag, or, when the tool needs only the
+   Python standard library, use an official `python:3.x-slim` image and write the logic inline.
+   **Do not invent an image or flag you cannot verify** -- ask instead. See "Choosing a container"
+   below. Lint will *not* catch a bad image; the job simply fails to pull it.
+3. **Draft the definition** using `references/schema-reference.md`. Reference each input as
+   `$(inputs.name.path)` (data) or `$(inputs.name)` (scalar). Write outputs to fixed filenames and
+   claim them with `from_work_dir` / `discover_datasets`.
+4. **Self-review** against `references/common-mistakes.md` (it doubles as a checklist).
+5. **Validate** (see below) and iterate on real errors.
+6. **Create + run.** Hand the validated definition to `create_user_tool`, then `run_user_tool`
+   (this skill stops at a valid definition -- the run/invocation loop is the caller's job).
+
+## Choosing a Container
+
+The container is the part most likely to pass validation but fail at run time, because nothing in
+the schema or lint checks that the image actually exists or pulls. A real example: a plotting UDT
+that declared `quay.io/biocontainers/seaborn:0.13.2--pyhd8ed1ab_3` was accepted by
+`create_user_tool`, then the job died with `manifest unknown` -- that exact build tag did not exist
+on quay. Guard against it:
+
+- **Don't guess the biocontainers build suffix** (`--<hash>_<build>`). It is not derivable from the
+  version. Look up the real tag: browse `https://quay.io/repository/biocontainers/<tool>?tab=tags`
+  or query `https://quay.io/api/v1/repository/biocontainers/<tool>/tag/?onlyActiveTags=true`.
+- **For a stdlib-only tool, skip biocontainers entirely.** Use an official base image like
+  `python:3.11-slim` (or `busybox` for shell-only) and write the logic inline (see the heredoc
+  pattern in `references/templating.md`). The seaborn failure above was fixed exactly this way:
+  switch to `python:3.11-slim` and emit SVG with the standard library, no third-party image to get
+  wrong.
+- **Never invent an image, tag, or CLI flag you can't verify** -- ask the user rather than guessing.
+
+## Validating a Definition
+
+Validation logic is pure Python in `galaxy-tool-util` -- the same code the server runs -- so you can
+check offline before submitting. Three tiers, weakest to strongest:
+
+1. **Local** (fast, offline, side-effect-free): `python scripts/validate.py my-tool.yml`. Needs
+   `pip install galaxy-tool-util`. Catches structural errors, the four semantic validators, and
+   lint warnings. Use this whenever a Python env is available (terminal, CI). See `scripts/`.
+2. **`planemo lint`** -- not available yet (planemo does not lint UDTs as of this writing); will be
+   the preferred ergonomic check once it lands.
+3. **Server create** -- `create_user_tool` / `POST /api/unprivileged_tools` runs the same lint and
+   confirms *this server* accepts it (needs `enable_beta_tool_formats` + the Custom Tool Execution
+   role). This is the final word, and the practical gate for environments without Python (e.g.
+   Loom): submit, then iterate on the returned errors.
+
+> **Lint-clean is necessary but not sufficient.** No check here -- not validate.py, not the server's
+> create lint -- verifies that the container image actually pulls or that the command succeeds.
+> Those only surface when the job runs. A nonexistent container tag (`manifest unknown` at run
+> time) is the most common real-world UDT failure, so verify the image (see "Choosing a Container")
+> before relying on a clean validation.
+
+## Common Patterns
+
+| Goal | shell_command snippet |
+|------|-----------------------|
+| Single data file path | `tool '$(inputs.reads.path)'` |
+| Scalar value | `tool --count $(inputs.count)` |
+| Multiple data files | `cat $(inputs.datasets.map(d => d.path).join(' ')) > out.txt` |
+| Boolean as a flag | `tool $(inputs.verbose ? '--verbose' : '')` |
+| Use the job's allocated cores | `tool --threads $GALAXY_SLOTS` (+ a `resource` requirement, `cores_min`) |
+| Capture one output file | declare output with `from_work_dir: out.txt` |
+| Capture many outputs | declare output `type: collection` with `discover_datasets` |
+| Run a non-trivial inline script | `python <<'PY'` ... `PY` heredoc; reference inputs as `$(inputs.x)` inside (see `references/templating.md`) |
+
+See `examples/` for seven complete, validated UDTs spanning these patterns.
+
+## Troubleshooting
+
+| Symptom / error code | Cause | Fix |
+|----------------------|-------|-----|
+| `dynamic_tool.output_unclaimed` | Output has no `from_work_dir`/`discover_datasets` | Write to a fixed filename and claim it |
+| `dynamic_tool.undeclared_input_ref` | `$(inputs.X)` with no input named `X` | Declare the input or fix the name |
+| `dynamic_tool.blank_container` | `container` empty / missing | Set a real container image string |
+| `string_pattern_mismatch` on `id` | Uppercase, leading digit, spaces | Use `^[a-z][a-z0-9_-]*$` |
+| extra-field rejection | XML-ism like `truevalue`, `command`, `${on_string}` | Remove it -- schema is `extra="forbid"` |
+| `manifest unknown` / `Unable to find image` at **run** time | Container tag doesn't exist on the registry | Use a real, verified tag (or `python:3.x-slim` for stdlib tools) -- lint can't catch this |
+
+Full list with the why behind each: `references/common-mistakes.md`.
+
+## Resources
+
+- `references/schema-reference.md` -- every `UserToolSource` field, input/output types, validators
+- `references/templating.md` -- the `$(...)` ECMAScript model, arrays, `$GALAXY_SLOTS`, escaping
+- `references/common-mistakes.md` -- pre-submit self-review checklist
+- `scripts/validate.py` -- offline validate + lint via `galaxy-tool-util`
+- `examples/` -- seven complete UDTs, simple to complex (incl. an inline-script `python:slim` tool)
+- Galaxy docs: [User-Defined Tools](https://docs.galaxyproject.org/en/master/admin/user_defined_tools.html)
+- For classic XML tools instead: the `tool-dev` skill.

--- a/udt-authoring/SKILL.md
+++ b/udt-authoring/SKILL.md
@@ -32,10 +32,14 @@ A UDT = a **container** + a **`shell_command`** + typed **`inputs`** and **`outp
 - Parameters are interpolated with **sandboxed ECMAScript inside `$(...)`** -- NOT Cheetah `$x` and
   NOT `#for#` loops. A data file's path is `$(inputs.name.path)`; a scalar value is
   `$(inputs.name)`.
-- The sandbox has **no database, filesystem, or network access**. Every UDT **must run in a
-  container** (`container:` is a required plain string).
-- Every output must **claim a file** it produced via `from_work_dir` (one file) or
-  `discover_datasets` (many) -- you do not write to a templated output path.
+- The `$(...)` templating sandbox has **no database or filesystem access**. Every UDT **must run in
+  a container** (`container:` is a required plain string); whether that container has network access
+  is set by the Galaxy admin's job config, not by the tool.
+- Every **dataset/collection** output must **claim a file** it produced via `from_work_dir` (one
+  file) or `discover_datasets` (many) -- you do not write to a templated output path.
+- Scalar `text`/`select` values interpolate into `shell_command` **unquoted** (unlike `base_command`
+  args, which are `shlex.quote`d) -- a value with spaces or quotes breaks the command. Quote them,
+  or pass free text via a configfile. See `references/templating.md`.
 
 If you find yourself writing `command:`, `$param`, `#for#`, `truevalue:`, or `${on_string}`, stop
 -- those are XML/Cheetah habits the schema rejects. See `references/common-mistakes.md`.
@@ -152,14 +156,29 @@ check offline before submitting. Three tiers, weakest to strongest:
 > create lint -- verifies that the container image actually pulls or that the command succeeds.
 > Those only surface when the job runs. A nonexistent container tag (`manifest unknown` at run
 > time) is the most common real-world UDT failure, so verify the image (see "Choosing a Container")
-> before relying on a clean validation.
+> before relying on a clean validation. It also can't see runtime JS-expression errors, shell
+> quoting, the server's role/config gates, or whether the command actually produces the declared
+> outputs -- only running the tool does.
 
 ## Iterating & Cleanup
 
 There is no in-place update API -- every `create_user_tool` call makes a **new** tool. When you
 iterate, bump `version` (e.g. `0.1.0` -> `0.2.0`); Galaxy keeps every prior version under the user's
-account. Heavy iteration accumulates stale versions, so once a design stabilizes, offer to remove the
-superseded ones with `delete_user_tool`.
+account. Heavy iteration accumulates stale versions, so once a design stabilizes, offer to deactivate
+the superseded ones with `delete_user_tool` -- it marks the tool inactive (hidden from the toolbox),
+not a hard delete; the records remain.
+
+## Limitations
+
+UDTs deliberately can't reach several things classic tools can (per the Galaxy docs):
+
+- **No reference data** -- no built-in genome indexes or `.loc` files.
+- **No metadata files** -- e.g. a BAM index (`.bai`) isn't available; if the command needs one, build
+  it inside the `shell_command` or take it as an explicit `data` input.
+- **No `extra_files` directory** -- composite / extra-file outputs aren't supported.
+
+Design around these: pass whatever the tool needs as an explicit input, and generate any side files
+inside the container.
 
 ## Common Patterns
 
@@ -187,7 +206,7 @@ See `examples/` for seven complete, validated UDTs spanning these patterns.
 | extra-field rejection | XML-ism like `truevalue`, `command`, `${on_string}` | Remove it -- schema is `extra="forbid"` |
 | `manifest unknown` / `Unable to find image` at **run** time | Container tag doesn't exist on the registry | Use a real, verified tag (or `python:3.x-slim` for stdlib tools) -- lint can't catch this |
 | HTTP 403 "not allowed to run unprivileged" | The admin's job routing (TPV) rejects `tool_type_user_defined` by default | Not fixable client-side -- the admin must add a destination/routing rule for user-defined tools |
-| HTTP 400 on `help` | `help` sent as a bare string | Use the object form: `help: {format, content}` |
+| `help` rejected at create | `help` sent as a bare string | Use the object form: `help: {format, content}` |
 
 Full list with the why behind each: `references/common-mistakes.md`.
 

--- a/udt-authoring/examples/01-minimal-echo.yml
+++ b/udt-authoring/examples/01-minimal-echo.yml
@@ -1,0 +1,20 @@
+# Smallest useful UDT: one text input, one captured output.
+class: GalaxyUserTool
+id: echo-message
+version: "0.1.0"
+name: Echo a message
+description: Write a user-provided message to a text file
+container: busybox
+shell_command: |
+  echo "$(inputs.message)" > out.txt
+inputs:
+  - name: message
+    type: text
+    value: "Hello, Galaxy!"
+    label: Message to write
+outputs:
+  - name: out
+    type: data
+    format: txt
+    from_work_dir: out.txt
+    label: Message file

--- a/udt-authoring/examples/01-minimal-echo.yml
+++ b/udt-authoring/examples/01-minimal-echo.yml
@@ -18,3 +18,10 @@ outputs:
     format: txt
     from_work_dir: out.txt
     label: Message file
+help:
+  format: markdown
+  content: |
+    Writes a user-provided message to a text file.
+
+    **Inputs** -- `message`: the text to write.
+    **Outputs** -- `out`: a text file containing the message.

--- a/udt-authoring/examples/02-single-data-in-out.yml
+++ b/udt-authoring/examples/02-single-data-in-out.yml
@@ -1,0 +1,20 @@
+# One data input referenced by .path, transformed, one output claimed by from_work_dir.
+class: GalaxyUserTool
+id: to-uppercase
+version: "0.1.0"
+name: Uppercase a text file
+description: Convert all letters in a text file to uppercase
+container: busybox
+shell_command: |
+  tr '[:lower:]' '[:upper:]' < '$(inputs.input.path)' > upper.txt
+inputs:
+  - name: input
+    type: data
+    format: txt
+    label: Input text file
+outputs:
+  - name: output
+    type: data
+    format: txt
+    from_work_dir: upper.txt
+    label: Uppercased text

--- a/udt-authoring/examples/02-single-data-in-out.yml
+++ b/udt-authoring/examples/02-single-data-in-out.yml
@@ -18,3 +18,10 @@ outputs:
     format: txt
     from_work_dir: upper.txt
     label: Uppercased text
+help:
+  format: markdown
+  content: |
+    Converts all letters in a text file to uppercase.
+
+    **Inputs** -- `input`: a text file.
+    **Outputs** -- `output`: the same text, uppercased.

--- a/udt-authoring/examples/03-multiple-data-js.yml
+++ b/udt-authoring/examples/03-multiple-data-js.yml
@@ -1,0 +1,21 @@
+# A multiple:true data input is an array -- map over it to build the command.
+# format_source copies the output datatype from an input instead of hardcoding it.
+class: GalaxyUserTool
+id: concatenate-files
+version: "0.1.0"
+name: Concatenate files
+description: Concatenate one or more files head-to-tail
+container: busybox
+shell_command: |
+  cat $(inputs.datasets.map((input) => input.path).join(' ')) > output.txt
+inputs:
+  - name: datasets
+    type: data
+    multiple: true
+    label: Files to concatenate
+outputs:
+  - name: output
+    type: data
+    format_source: datasets
+    from_work_dir: output.txt
+    label: Concatenated output

--- a/udt-authoring/examples/03-multiple-data-js.yml
+++ b/udt-authoring/examples/03-multiple-data-js.yml
@@ -19,3 +19,10 @@ outputs:
     format_source: datasets
     from_work_dir: output.txt
     label: Concatenated output
+help:
+  format: markdown
+  content: |
+    Concatenates one or more files head-to-tail into a single file.
+
+    **Inputs** -- `datasets`: one or more files.
+    **Outputs** -- `output`: the concatenated result (datatype copied from the inputs).

--- a/udt-authoring/examples/04-select-integer-boolean.yml
+++ b/udt-authoring/examples/04-select-integer-boolean.yml
@@ -1,0 +1,34 @@
+# Scalar parameter types: select (with options), integer (with bounds), and a
+# boolean turned into a flag via a ternary -- NOT truevalue/falsevalue.
+class: GalaxyUserTool
+id: repeat-greeting
+version: "0.1.0"
+name: Repeat a greeting
+description: Print a chosen greeting a number of times, optionally shouting
+container: busybox
+shell_command: |
+  yes "$(inputs.greeting)$(inputs.shout ? '!' : '')" | head -n $(inputs.count) > greetings.txt
+inputs:
+  - name: greeting
+    type: select
+    label: Greeting
+    help: Which greeting to print.
+    options:
+      - { label: Hi, value: Hi, selected: true }
+      - { label: Hello, value: Hello, selected: false }
+  - name: count
+    type: integer
+    value: 3
+    min: 1
+    max: 100
+    label: Number of lines
+  - name: shout
+    type: boolean
+    value: false
+    label: Add an exclamation mark
+outputs:
+  - name: output
+    type: data
+    format: txt
+    from_work_dir: greetings.txt
+    label: Greetings

--- a/udt-authoring/examples/04-select-integer-boolean.yml
+++ b/udt-authoring/examples/04-select-integer-boolean.yml
@@ -32,3 +32,10 @@ outputs:
     format: txt
     from_work_dir: greetings.txt
     label: Greetings
+help:
+  format: markdown
+  content: |
+    Prints a chosen greeting a number of times, optionally with an exclamation mark.
+
+    **Inputs** -- `greeting` (Hi/Hello), `count` (1-100), `shout` (adds "!").
+    **Outputs** -- `output`: the greetings, one per line.

--- a/udt-authoring/examples/05-resource-requirements.yml
+++ b/udt-authoring/examples/05-resource-requirements.yml
@@ -17,3 +17,9 @@ outputs:
     format: txt
     from_work_dir: galaxy_cores.txt
     label: Allocated cores
+help:
+  format: markdown
+  content: |
+    Reports the number of CPU cores Galaxy allocated to the job (from `$GALAXY_SLOTS`).
+
+    **Outputs** -- `cores`: a one-line text file with the core count.

--- a/udt-authoring/examples/05-resource-requirements.yml
+++ b/udt-authoring/examples/05-resource-requirements.yml
@@ -1,0 +1,19 @@
+# Request cores with a resource requirement; read the allocation at runtime via
+# the $GALAXY_SLOTS shell variable (no parentheses -> not a $() expression).
+class: GalaxyUserTool
+id: report-cores
+version: "0.1.0"
+name: Report allocated cores
+description: Write the number of CPU cores Galaxy allocated to this job
+container: busybox
+requirements:
+  - type: resource
+    cores_min: 2
+shell_command: |
+  echo "$GALAXY_SLOTS" > galaxy_cores.txt
+outputs:
+  - name: cores
+    type: data
+    format: txt
+    from_work_dir: galaxy_cores.txt
+    label: Allocated cores

--- a/udt-authoring/examples/06-biocontainer-tool.yml
+++ b/udt-authoring/examples/06-biocontainer-tool.yml
@@ -1,0 +1,29 @@
+# Realistic capstone: a real bioinformatics tool in a biocontainer, multiple data
+# inputs joined with .map().join(), threads from $GALAXY_SLOTS, tabular output.
+#
+# IMPORTANT: verify the exact container tag exists before use -- do not guess.
+# Browse https://quay.io/repository/biocontainers/seqkit?tab=tags for current tags.
+class: GalaxyUserTool
+id: seqkit-stats
+version: "0.1.0"
+name: SeqKit sequence statistics
+description: Summary statistics (num seqs, length, N50, GC) for FASTA/FASTQ files
+container: quay.io/biocontainers/seqkit:2.8.2--h9ee0642_0
+requirements:
+  - type: resource
+    cores_min: 2
+shell_command: |
+  seqkit stats --tabular --all --threads $GALAXY_SLOTS $(inputs.input_files.map((f) => f.path).join(' ')) > stats.tsv
+inputs:
+  - name: input_files
+    type: data
+    format: [fasta, fastq]
+    multiple: true
+    label: Input sequence file(s)
+    help: One or more FASTA or FASTQ files to summarize.
+outputs:
+  - name: report
+    type: data
+    format: tabular
+    from_work_dir: stats.tsv
+    label: Sequence statistics (TSV)

--- a/udt-authoring/examples/06-biocontainer-tool.yml
+++ b/udt-authoring/examples/06-biocontainer-tool.yml
@@ -27,3 +27,12 @@ outputs:
     format: tabular
     from_work_dir: stats.tsv
     label: Sequence statistics (TSV)
+help:
+  format: markdown
+  content: |
+    Computes summary statistics (num seqs, length, N50, GC) for FASTA/FASTQ files with `seqkit stats`.
+
+    **Inputs** -- `input_files`: one or more FASTA/FASTQ files.
+    **Outputs** -- `report`: a tabular statistics report.
+
+    Uses the job's allocated cores (`$GALAXY_SLOTS`).

--- a/udt-authoring/examples/07-inline-python-script.yml
+++ b/udt-authoring/examples/07-inline-python-script.yml
@@ -45,3 +45,12 @@ outputs:
     format: txt
     from_work_dir: summary.txt
     label: Column summary
+help:
+  format: markdown
+  content: |
+    Reports count, mean, min, and max of one numeric column in a tabular file.
+
+    **Inputs** -- `table`: a tabular file; `column`: the column header to summarize.
+    **Outputs** -- `summary`: a small text report.
+
+    The column must match a header in the file; non-numeric/empty cells are skipped.

--- a/udt-authoring/examples/07-inline-python-script.yml
+++ b/udt-authoring/examples/07-inline-python-script.yml
@@ -1,0 +1,47 @@
+# Real-world pattern: a stdlib-only Python tool in an OFFICIAL python:3.x-slim image
+# (not a biocontainer whose build-hash tag you'd have to guess), with the script
+# embedded via a quoted heredoc. Modeled on a plotting UDT whose seaborn-biocontainer
+# tag did not exist at run time -- switching to python:3.11-slim + stdlib was the fix.
+class: GalaxyUserTool
+id: column-summary
+version: "0.1.0"
+name: Summarize a numeric column
+description: Report count, mean, min, and max of one numeric column in a tabular file
+container: python:3.11-slim
+shell_command: |
+  python <<'PY'
+  import csv
+  path = '$(inputs.table.path)'
+  column = '$(inputs.column)'
+  values = []
+  with open(path, newline='') as fh:
+      reader = csv.DictReader(fh, delimiter='\t')
+      for row in reader:
+          cell = row.get(column, '')
+          if cell not in ('', None):
+              values.append(float(cell))
+  if not values:
+      raise SystemExit(f'No numeric values found in column {column!r}')
+  n = len(values)
+  with open('summary.txt', 'w') as out:
+      out.write(f'column\t{column}\n')
+      out.write(f'count\t{n}\n')
+      out.write(f'mean\t{sum(values) / n}\n')
+      out.write(f'min\t{min(values)}\n')
+      out.write(f'max\t{max(values)}\n')
+  PY
+inputs:
+  - name: table
+    type: data
+    format: tabular
+    label: Tabular input
+  - name: column
+    type: text
+    label: Column name to summarize
+    help: Must match a column header in the tabular file.
+outputs:
+  - name: summary
+    type: data
+    format: txt
+    from_work_dir: summary.txt
+    label: Column summary

--- a/udt-authoring/references/common-mistakes.md
+++ b/udt-authoring/references/common-mistakes.md
@@ -13,7 +13,7 @@ plus a few schema-specific traps. Run through this before submitting.
 - [ ] `id` matches `^[a-z][a-z0-9_-]*$`; `name` is at least 5 characters.
 - [ ] No rejected fields: `truevalue`, `falsevalue`, `argument`, `parameter_type`, `${on_string}`, `${tool.name}`.
 - [ ] Booleans become flags via a ternary, not `truevalue`/`falsevalue`.
-- [ ] Threads/cores use `$GALAXY_SLOTS` (+ a `resource` requirement) unless manual control is wanted.
+- [ ] The parallelism flag's **value** is `$GALAXY_SLOTS` (+ a `resource` requirement), not a hardcoded number -- and not merely echoed to a log while the flag stays a literal.
 - [ ] Optional parameters have sensible `value` defaults.
 - [ ] Labels and description say what the tool actually does (not "Run the tool").
 - [ ] A real `help` block is present (object form `{format, content}`, no `TODO` placeholder).
@@ -33,7 +33,7 @@ plus a few schema-specific traps. Run through this before submitting.
 | `truevalue: --x` / `falsevalue: ""` on a boolean | XML-only fields, rejected. | `value: false` + `$(inputs.x ? '--x' : '')` in the command. |
 | `${on_string}`, `${tool.name}` in labels | Cheetah macros; not supported. | Use a plain string label, or `format_source` to inherit. |
 | `id: My_Tool` / `id: 2pass` | Must be lowercase and start with a letter (`string_pattern_mismatch`). | `id: my-tool`, `id: two-pass`. |
-| Hardcoded `--threads 8` | Ignores the job's real allocation. | `--threads $GALAXY_SLOTS` + `resource` `cores_min`. |
+| Hardcoded `--threads 8` -- even while echoing `$GALAXY_SLOTS` elsewhere | Ignores the job's real allocation; recording the value isn't using it. | Make the flag's value `$GALAXY_SLOTS` (`--threads $GALAXY_SLOTS`) + `resource` `cores_min`. |
 | `container: ubuntu:latest` for a bioinformatics tool | Generic image won't have the binary; not reproducible. | Use the tool's biocontainer. |
 | Invented image/tag/flags | A guessed container or CLI flag fails at runtime. | Use only images/flags you can verify; otherwise ask. |
 | Unescaped literal `$(date)` in the command | Galaxy treats `$(...)` as an expression and errors/misfires. | Escape it: `\$(date)`. |

--- a/udt-authoring/references/common-mistakes.md
+++ b/udt-authoring/references/common-mistakes.md
@@ -16,6 +16,7 @@ plus a few schema-specific traps. Run through this before submitting.
 - [ ] Threads/cores use `$GALAXY_SLOTS` (+ a `resource` requirement) unless manual control is wanted.
 - [ ] Optional parameters have sensible `value` defaults.
 - [ ] Labels and description say what the tool actually does (not "Run the tool").
+- [ ] A real `help` block is present (object form `{format, content}`, no `TODO` placeholder).
 
 ## Mistakes table
 
@@ -35,6 +36,7 @@ plus a few schema-specific traps. Run through this before submitting.
 | `container: ubuntu:latest` for a bioinformatics tool | Generic image won't have the binary; not reproducible. | Use the tool's biocontainer. |
 | Invented image/tag/flags | A guessed container or CLI flag fails at runtime. | Use only images/flags you can verify; otherwise ask. |
 | Unescaped literal `$(date)` in the command | Galaxy treats `$(...)` as an expression and errors/misfires. | Escape it: `\$(date)`. |
+| `help` omitted, a bare string, or a `TODO` stub | Galaxy wants `{format, content}`; an empty/missing help leaves a documentation-free black box on the tool page. | Write a real help block: 3 short paragraphs (what / inputs+outputs / caveats). |
 
 ## Verifying a container (the #1 runtime failure)
 

--- a/udt-authoring/references/common-mistakes.md
+++ b/udt-authoring/references/common-mistakes.md
@@ -1,0 +1,62 @@
+# Common Mistakes & Pre-Submit Checklist
+
+UDTs are modeled after XML tools, so the most common failures are XML/Cheetah habits leaking in,
+plus a few schema-specific traps. Run through this before submitting.
+
+## Checklist
+
+- [ ] Command is under **`shell_command`**, not `command`.
+- [ ] Parameters use **`$(inputs.x)`** / **`$(inputs.x.path)`**, not Cheetah `$x` or `#for#`.
+- [ ] `container` is a **plain string** of a **real** image (verified biocontainer when possible).
+- [ ] Every output has **`from_work_dir`** or **`discover_datasets`** (collections: `discover_datasets`).
+- [ ] Every `$(inputs.X)` reference has a matching declared input named `X`.
+- [ ] `id` matches `^[a-z][a-z0-9_-]*$`; `name` is at least 5 characters.
+- [ ] No rejected fields: `truevalue`, `falsevalue`, `argument`, `parameter_type`, `${on_string}`, `${tool.name}`.
+- [ ] Booleans become flags via a ternary, not `truevalue`/`falsevalue`.
+- [ ] Threads/cores use `$GALAXY_SLOTS` (+ a `resource` requirement) unless manual control is wanted.
+- [ ] Optional parameters have sensible `value` defaults.
+- [ ] Labels and description say what the tool actually does (not "Run the tool").
+
+## Mistakes table
+
+| Mistake | Why it's wrong | Fix |
+|---------|----------------|-----|
+| `command: ...` | The field is `shell_command`; `command` is rejected (`extra="forbid"`). | Rename to `shell_command`. |
+| `$threads`, `#for f in $files#` | Cheetah templating. UDTs use sandboxed ECMAScript. | `$(inputs.threads)`, `$(inputs.files.map(f => f.path).join(' '))`. |
+| `'$(inputs.reads)'` for a data input | A data input is an object, not a path. | `'$(inputs.reads.path)'`. |
+| `container: {type: docker, image: ...}` | `container` is a plain string. | `container: quay.io/biocontainers/...`. |
+| Output written to `'$(inputs.out)'` / a templated output path | UDTs don't pass output paths in; the file is claimed afterward. | Write to a fixed filename, then `from_work_dir: that-file`. |
+| Output with neither `from_work_dir` nor `discover_datasets` | `dynamic_tool.output_unclaimed`. | Add one of them. |
+| `$(inputs.foo)` but no input `foo` | `dynamic_tool.undeclared_input_ref`. | Declare `foo` or fix the typo. |
+| `truevalue: --x` / `falsevalue: ""` on a boolean | XML-only fields, rejected. | `value: false` + `$(inputs.x ? '--x' : '')` in the command. |
+| `${on_string}`, `${tool.name}` in labels | Cheetah macros; not supported. | Use a plain string label, or `format_source` to inherit. |
+| `id: My_Tool` / `id: 2pass` | Must be lowercase and start with a letter (`string_pattern_mismatch`). | `id: my-tool`, `id: two-pass`. |
+| Hardcoded `--threads 8` | Ignores the job's real allocation. | `--threads $GALAXY_SLOTS` + `resource` `cores_min`. |
+| `container: ubuntu:latest` for a bioinformatics tool | Generic image won't have the binary; not reproducible. | Use the tool's biocontainer. |
+| Invented image/tag/flags | A guessed container or CLI flag fails at runtime. | Use only images/flags you can verify; otherwise ask. |
+| Unescaped literal `$(date)` in the command | Galaxy treats `$(...)` as an expression and errors/misfires. | Escape it: `\$(date)`. |
+
+## Verifying a container (the #1 runtime failure)
+
+A wrong container is the most common way a UDT passes validation and then fails at run time --
+schema/lint never check that the image exists. Real case: a plotting UDT declared
+`quay.io/biocontainers/seaborn:0.13.2--pyhd8ed1ab_3`, was accepted by `create_user_tool`, and the
+job died with `manifest unknown` because that exact build tag didn't exist on quay.
+
+- **Never guess the biocontainers build suffix** (`--<hash>_<build>`) -- it isn't derivable from the
+  version number. Look it up: browse `https://quay.io/repository/biocontainers/<tool>?tab=tags` or
+  query `https://quay.io/api/v1/repository/biocontainers/<tool>/tag/?onlyActiveTags=true`.
+- **Stdlib-only tool? Skip biocontainers.** Use `python:3.x-slim` (or `busybox` for shell-only) and
+  write the logic inline -- there's no third-party tag to get wrong. The seaborn failure above was
+  fixed precisely this way: switch to `python:3.11-slim` and emit SVG with the standard library.
+- **A clean `validate.py` does not mean the image pulls.** Lint validates the YAML, not the
+  registry. Verify the image separately, or let the server-create + first run confirm it.
+
+## Clarity pass (what a deterministic validator can't catch)
+
+The schema accepts plenty of unhelpful-but-valid tools. Before finishing, also check:
+
+- `description` states what the tool does, specifically.
+- Non-obvious inputs have `help` text; `label`s aren't just the parameter name repeated.
+- Common, useful options for the wrapped tool are exposed (e.g. a threads input for an aligner).
+- Defaults are sensible so a user can run it without filling in everything.

--- a/udt-authoring/references/common-mistakes.md
+++ b/udt-authoring/references/common-mistakes.md
@@ -17,6 +17,7 @@ plus a few schema-specific traps. Run through this before submitting.
 - [ ] Optional parameters have sensible `value` defaults.
 - [ ] Labels and description say what the tool actually does (not "Run the tool").
 - [ ] A real `help` block is present (object form `{format, content}`, no `TODO` placeholder).
+- [ ] Scalar `text`/`select` values are quoted in `shell_command` (or passed via a configfile) -- they interpolate unquoted.
 
 ## Mistakes table
 
@@ -37,6 +38,7 @@ plus a few schema-specific traps. Run through this before submitting.
 | Invented image/tag/flags | A guessed container or CLI flag fails at runtime. | Use only images/flags you can verify; otherwise ask. |
 | Unescaped literal `$(date)` in the command | Galaxy treats `$(...)` as an expression and errors/misfires. | Escape it: `\$(date)`. |
 | `help` omitted, a bare string, or a `TODO` stub | Galaxy wants `{format, content}`; an empty/missing help leaves a documentation-free black box on the tool page. | Write a real help block: 3 short paragraphs (what / inputs+outputs / caveats). |
+| Free-text scalar inlined unquoted in `shell_command` | `$(inputs.x)` for `text`/`select` interpolates raw (no `shlex.quote`); spaces/quotes break or inject into the command. | Quote it (`'$(inputs.x)'`) or pass free text via a configfile; fixed `select`/numeric values are safe. |
 
 ## Verifying a container (the #1 runtime failure)
 

--- a/udt-authoring/references/schema-reference.md
+++ b/udt-authoring/references/schema-reference.md
@@ -21,7 +21,7 @@ rejected at parse time.** Field names below are exact.
 | `configfiles` | no | list | Files written before execution; content supports `$(...)`. |
 | `citations` | no | list | `{type: doi|bibtex|reference, content: ...}`. DOIs/bibtex are validated. |
 | `license` | no | string | SPDX identifier, e.g. `MIT`. |
-| `help` | no | string/markdown | Help text under the tool form. |
+| `help` | no (convention: yes) | object | `{format, content}`; `format` is `markdown`/`restructuredtext`/`plain_text`. Rendered under the tool form. Always include one -- see SKILL.md. |
 | `tests` | no | list | In-tool tests (inputs/outputs). |
 | `profile`, `edam_operations`, `edam_topics`, `xrefs` | no | -- | Metadata; rarely needed for a first version. |
 

--- a/udt-authoring/references/schema-reference.md
+++ b/udt-authoring/references/schema-reference.md
@@ -1,0 +1,112 @@
+# UserToolSource Schema Reference
+
+The canonical schema for a UDT is the `UserToolSource` Pydantic model in
+`galaxy-tool-util` (`galaxy.tool_util_models`). It is `extra="forbid"`: **any unknown field is
+rejected at parse time.** Field names below are exact.
+
+## Top-level fields
+
+| Field | Required | Type | Notes |
+|-------|----------|------|-------|
+| `class` | **yes** | string | Must be exactly `GalaxyUserTool`. |
+| `name` | **yes** | string | Display name; **min length 5**; not blank/whitespace. |
+| `container` | **yes** | string | Container image, e.g. `quay.io/biocontainers/seqkit:2.8.2--h9ee0642_0`. A plain **string**, never a dict/list. Not blank. |
+| `shell_command` | **yes** | string | Command with `$(...)` expressions. The field is `shell_command`, not `command`. |
+| `id` | no (recommended) | string | Pattern `^[a-z][a-z0-9_-]*$`, length 3-255. Lowercase, starts with a letter; hyphens and underscores allowed. |
+| `version` | no (recommended) | string | e.g. `"0.1.0"`. Not blank/whitespace. Quote it so YAML doesn't read it as a number. |
+| `description` | no | string | Short line in the tool menu. |
+| `inputs` | no (default `[]`) | list | Input parameters (see below). |
+| `outputs` | no (default `[]`) | list | Output definitions (see below). |
+| `requirements` | no | list | `javascript` / `resource` / `container` requirements (see below). |
+| `configfiles` | no | list | Files written before execution; content supports `$(...)`. |
+| `citations` | no | list | `{type: doi|bibtex|reference, content: ...}`. DOIs/bibtex are validated. |
+| `license` | no | string | SPDX identifier, e.g. `MIT`. |
+| `help` | no | string/markdown | Help text under the tool form. |
+| `tests` | no | list | In-tool tests (inputs/outputs). |
+| `profile`, `edam_operations`, `edam_topics`, `xrefs` | no | -- | Metadata; rarely needed for a first version. |
+
+## Input parameter types
+
+Every input has `name` (required) and may have `label`, `help`, `optional` (default `false`).
+Beyond those, each type supports:
+
+| `type` | Extra supported fields |
+|--------|------------------------|
+| `boolean` | `value` (true/false). **No** `truevalue`/`falsevalue` -- turn it into a flag in `shell_command` with a ternary. |
+| `integer` | `value` (default), `min`, `max`, `validators` (`in_range`) |
+| `float` | `value`, `min`, `max`, `validators` (`in_range`) |
+| `text` | `value`, `area` (bool), `validators` (`length`, `regex`, `empty_field`) |
+| `select` | `options` (static, non-empty), `multiple`, `validators` (`no_options`) |
+| `color` | `value` |
+| `data` | `format` (string or list of datatypes), `multiple`, `min`, `max` |
+| `data_collection` | `collection_type` (e.g. `list`, `paired`), `format` |
+
+`select` options are a list of `{label, value, selected}`:
+
+```yaml
+- name: mode
+  type: select
+  options:
+    - { label: Fast, value: fast, selected: true }
+    - { label: Accurate, value: accurate, selected: false }
+```
+
+**Structural groups** (recurse into the leaf types above): `conditional` (has `test_parameter`
+and `whens`), `repeat` (has `parameters`, `min`, `max`), `section` (has `parameters`).
+
+**Rejected types** (exist in XML, not in UDT -- parse error): `hidden`, `drill_down`,
+`data_column`, `genomebuild`, `group_tag`, `baseurl`, `rules`, `directory`. **Rejected fields on
+any parameter:** `truevalue`, `falsevalue`, `argument`, `is_dynamic`, `hidden`, `parameter_type`.
+
+## Output types
+
+Every output has `name` and `type`. **A dataset output must declare `from_work_dir` OR
+`discover_datasets`; a collection output must declare `discover_datasets`.** Omitting both is the
+`dynamic_tool.output_unclaimed` error.
+
+**Dataset output** (`type: data`):
+
+| Field | Notes |
+|-------|-------|
+| `from_work_dir` | Relative path to the file your command wrote, e.g. `out.vcf`. |
+| `format` | Datatype, e.g. `vcf`, `tabular`, `bam`. |
+| `format_source` | Copy the format from a named input instead of hardcoding. |
+| `metadata_source` | Copy metadata from a named input. |
+| `label` | History display name. |
+| `discover_datasets` | Alternative to `from_work_dir` for pattern-matched files. |
+
+**Collection output** (`type: collection`): `collection_type` (`list`, `paired`, ...) plus
+`discover_datasets` (required). Discovery is either a `pattern` (glob with `__name_and_ext__` etc.)
+or `tool_provided_metadata`.
+
+## Requirements
+
+Prefer the top-level `container:` field for the image. The `requirements` list is for:
+
+```yaml
+requirements:
+  - type: resource          # request cores/ram; exposes $GALAXY_SLOTS at runtime
+    cores_min: 4
+  - type: javascript        # helper functions usable inside $(...)
+    expression_lib:
+      - |
+        function basename(p) { return p.split('/').pop(); }
+```
+
+`resource` supports `cores_min`/`cores_max`, `ram_min`/`ram_max`, `tmpdir_*`, GPU fields, and
+`timelimit`. A `container` requirement also exists but the top-level `container` field is the
+idiomatic choice.
+
+## The four semantic validators (stable error codes)
+
+Beyond type/shape checks, `UserToolSource` runs these. Error `code`s are stable across releases:
+
+| Code | Rule |
+|------|------|
+| `dynamic_tool.blank_string` | `name` and `version` must not be empty/whitespace. |
+| `dynamic_tool.blank_container` | `container` must not be empty/whitespace. |
+| `dynamic_tool.undeclared_input_ref` | Every `inputs.X` referenced in `shell_command` or a configfile must be a declared input. References resolve against the **top-level** name (a conditional's `inputs.cond.test_parameter` resolves via `cond`). |
+| `dynamic_tool.output_unclaimed` | Each dataset output needs `from_work_dir` or `discover_datasets`; each collection output needs `discover_datasets`. |
+
+`id` violations surface as Pydantic's `string_pattern_mismatch`; a too-short `name` as
+`string_too_short`.

--- a/udt-authoring/references/schema-reference.md
+++ b/udt-authoring/references/schema-reference.md
@@ -76,12 +76,37 @@ Every output has `name` and `type`. **A dataset output must declare `from_work_d
 | `discover_datasets` | Alternative to `from_work_dir` for pattern-matched files. |
 
 **Collection output** (`type: collection`): `collection_type` (`list`, `paired`, ...) plus
-`discover_datasets` (required). Discovery is either a `pattern` (glob with `__name_and_ext__` etc.)
-or `tool_provided_metadata`.
+`discover_datasets` (required). Discovery is either a `pattern` or `tool_provided_metadata`. The
+`UserToolSource` model does **not** default the discovery fields, so a bare `[{pattern: ...}]` fails
+validation -- a pattern entry needs all of `discover_via`, `pattern`, `directory`, `format`,
+`visible`, `recurse`, `match_relative_path`, `assign_primary_output`, `sort_key`, `sort_comp`:
+
+```yaml
+outputs:
+  - name: parts
+    type: collection
+    collection_type: list
+    discover_datasets:
+      - discover_via: pattern
+        pattern: 'part_(?P<designation>.+)\.txt'   # named groups: designation, ext, dbkey
+        directory: outdir
+        format: txt
+        visible: false
+        recurse: false
+        match_relative_path: false
+        assign_primary_output: false
+        sort_key: filename        # filename | name | designation | dbkey
+        sort_comp: lexical        # lexical | numeric
+```
+
+**Only `data` and `collection` outputs are supported.** The scalar output types present in the
+underlying model (`ToolOutputText`/`Integer`/`Float`/`Boolean`) are rejected by the UDT YAML parser
+-- don't use them.
 
 ## Requirements
 
-Prefer the top-level `container:` field for the image. The `requirements` list is for:
+Prefer the top-level `container:` field for the image -- it is required, and a `requirements:` entry
+of `type: container` does **not** satisfy it. The `requirements` list is for:
 
 ```yaml
 requirements:

--- a/udt-authoring/references/templating.md
+++ b/udt-authoring/references/templating.md
@@ -17,13 +17,27 @@ and any helpers you add via a `javascript` requirement's `expression_lib`.
 | A boolean turned into a flag | `$(inputs.trim ? '--trim' : '')` |
 | A select value chosen into an option | `$(inputs.mode === 'fast' ? '-x' : '-y')` |
 
-A `data` input is an **object** -- you almost always want `.path`, not the object itself. A
-`multiple: true` data input is an **array** of those objects; map over it.
+A `data` input is an **object** (a CWL-style File object, not a bare path string) -- you almost
+always want `.path`. A `multiple: true` data input is an **array** of those objects; map over it.
 
 ```yaml
 shell_command: |
   cat $(inputs.datasets.map((input) => input.path).join(' ')) > output.txt
 ```
+
+## Quoting: scalar values are not auto-quoted
+
+Galaxy substitutes `$(...)` expressions into `shell_command` as **raw text** -- unlike `base_command`
+arguments, they are *not* run through `shlex.quote`. So a `text` or `select` value containing a
+space, quote, `$`, or other shell metacharacter will break or alter the command (it is also an
+injection vector if the value is attacker-controlled).
+
+- **Quote interpolations defensively:** `'$(inputs.reads.path)'`, `'$(inputs.label)'`.
+- **For free-form text you don't control, prefer a configfile** -- write the value into a JSON file
+  and read it in the command, rather than inlining it (see Config files below).
+- **`select` inputs with a fixed option list, and numeric `integer`/`float`, are safe to inline** --
+  their values can't contain surprises.
+- Data `.path` values are Galaxy-generated and normally clean, but quoting them costs nothing.
 
 ## Job resources: `$GALAXY_SLOTS` (a shell variable, not an expression)
 
@@ -71,6 +85,10 @@ requirements:
 shell_command: |
   tool $(pick(inputs.fast, '--fast', '--accurate')) '$(inputs.reads.path)' > out.txt
 ```
+
+`expression_lib` and the `javascript` requirement are accepted by the UDT schema and wired up at
+runtime, but they aren't covered by the official UDT docs -- confirm on your target server before
+relying on them.
 
 ## Embedding a script (heredoc)
 

--- a/udt-authoring/references/templating.md
+++ b/udt-authoring/references/templating.md
@@ -57,6 +57,24 @@ shell_command: |
 Use `$GALAXY_SLOTS` for "however many cores the job got" -- this is usually what a user means by
 "number of threads." Expose an `integer` input only when the user needs explicit manual control.
 
+**Pass it as the flag's value -- recording it is not using it.** The parallelism flag's argument
+must *be* `$GALAXY_SLOTS` (`--threads $GALAXY_SLOTS`, `-@ $GALAXY_SLOTS`, `-p $GALAXY_SLOTS`).
+Echoing it to a log, or storing it in a variable you never pass through, does nothing for
+parallelism -- a command that prints `$GALAXY_SLOTS` "for debugging" but still runs `--threads 8`
+is hardcoded and ignores the real allocation. Wiring it through and logging it are independent: do
+the first; the second is optional.
+
+```yaml
+# WRONG -- "aware" of the allocation, but the flag is still hardcoded
+shell_command: |
+  echo "cores: $GALAXY_SLOTS"             # recorded...
+  samtools sort -@ 8 -o out.bam in.bam    # ...but ignored -- only 8 threads regardless
+
+# RIGHT -- the flag's value IS the allocation
+shell_command: |
+  samtools sort -@ $GALAXY_SLOTS -o out.bam in.bam
+```
+
 ## Escaping: literal shell `$(...)` must be `\$(...)`
 
 Galaxy intercepts `$(...)` as a JavaScript expression. If you need a **literal shell command

--- a/udt-authoring/references/templating.md
+++ b/udt-authoring/references/templating.md
@@ -1,0 +1,121 @@
+# Templating: `$(...)` ECMAScript, not Cheetah
+
+UDT commands and config files interpolate parameters with **sandboxed ECMAScript (JavaScript)
+expressions inside `$(...)`**. This is the single biggest difference from classic XML tools, which
+use Cheetah (`$param`, `#for#`, `#if#`). None of the Cheetah syntax works here.
+
+The sandbox has **no access to the database, filesystem, or network** -- only the `inputs` object
+and any helpers you add via a `javascript` requirement's `expression_lib`.
+
+## Referencing inputs
+
+| You want | Write |
+|----------|-------|
+| A scalar value (integer/float/text/boolean/select) | `$(inputs.count)` |
+| A single data file's path | `$(inputs.reads.path)` |
+| Multiple data files' paths, space-joined | `$(inputs.datasets.map(d => d.path).join(' '))` |
+| A boolean turned into a flag | `$(inputs.trim ? '--trim' : '')` |
+| A select value chosen into an option | `$(inputs.mode === 'fast' ? '-x' : '-y')` |
+
+A `data` input is an **object** -- you almost always want `.path`, not the object itself. A
+`multiple: true` data input is an **array** of those objects; map over it.
+
+```yaml
+shell_command: |
+  cat $(inputs.datasets.map((input) => input.path).join(' ')) > output.txt
+```
+
+## Job resources: `$GALAXY_SLOTS` (a shell variable, not an expression)
+
+The number of CPU cores allocated to the job is exposed as the **shell environment variable**
+`$GALAXY_SLOTS` (and memory as `$GALAXY_MEMORY_MB`). Because it has no parentheses, it is **not** a
+`$(...)` expression -- it passes through to the shell and expands at runtime. Request cores with a
+`resource` requirement:
+
+```yaml
+requirements:
+  - type: resource
+    cores_min: 4
+shell_command: |
+  seqkit stats --threads $GALAXY_SLOTS '$(inputs.reads.path)' > stats.tsv
+```
+
+Use `$GALAXY_SLOTS` for "however many cores the job got" -- this is usually what a user means by
+"number of threads." Expose an `integer` input only when the user needs explicit manual control.
+
+## Escaping: literal shell `$(...)` must be `\$(...)`
+
+Galaxy intercepts `$(...)` as a JavaScript expression. If you need a **literal shell command
+substitution** in your command, escape it so Galaxy passes it through:
+
+```yaml
+shell_command: |
+  echo "Run on \$(date)" > log.txt          # \$(date) -> shell runs `date`
+  echo "$(inputs.message)" >> log.txt        # $(inputs.message) -> Galaxy expands the input
+```
+
+A plain shell variable like `$GALAXY_SLOTS`, `$HOME`, or `$PWD` (no parentheses) needs **no**
+escaping -- only the parenthesized `$(...)` form collides with the expression syntax.
+
+## Helper functions via `expression_lib`
+
+For logic too awkward to inline, add ECMAScript 5.1 functions in a `javascript` requirement and
+call them inside `$(...)`:
+
+```yaml
+requirements:
+  - type: javascript
+    expression_lib:
+      - |
+        function pick(cond, a, b) { return cond ? a : b; }
+shell_command: |
+  tool $(pick(inputs.fast, '--fast', '--accurate')) '$(inputs.reads.path)' > out.txt
+```
+
+## Embedding a script (heredoc)
+
+For logic beyond a one-liner, embed a script with a shell heredoc and reference inputs with
+`$(inputs.x)` inside it. Galaxy expands the `$(...)` expressions **before** the shell runs, so a
+quoted heredoc (`<<'PY'`) is correct -- it stops the shell from re-expanding things, while Galaxy
+has already substituted the inputs:
+
+```yaml
+container: python:3.11-slim          # an inline Python script needs only a base Python image
+shell_command: |
+  python <<'PY'
+  import csv
+  table = '$(inputs.table.path)'      # Galaxy substitutes the path before the shell sees this
+  column = '$(inputs.column)'
+  with open(table) as fh:
+      rows = list(csv.DictReader(fh, delimiter='\t'))
+  with open('out.txt', 'w') as out:
+      out.write(str(len(rows)))
+  PY
+inputs:
+  - { name: table, type: data }
+  - { name: column, type: text }
+outputs:
+  - { name: out, type: data, format: txt, from_work_dir: out.txt }
+```
+
+Two reminders inside a heredoc: Galaxy still scans the whole `shell_command` for `$(inputs.X)`
+references (so they count toward `dynamic_tool.undeclared_input_ref`), and a **literal** shell
+command substitution like `$(date)` must still be escaped as `\$(date)`.
+
+## Config files
+
+`configfiles` content uses the same `$(...)` rules and is written to disk before the command runs:
+
+```yaml
+configfiles:
+  - name: params
+    filename: params.json
+    content: |
+      {"min_depth": $(inputs.min_dp), "input": "$(inputs.vcf.path)"}
+    eval_engine: ecmascript
+shell_command: |
+  mytool --config params.json > out.txt
+```
+
+Input references inside a configfile count toward `dynamic_tool.undeclared_input_ref`, same as in
+`shell_command`.

--- a/udt-authoring/scripts/validate.py
+++ b/udt-authoring/scripts/validate.py
@@ -24,13 +24,15 @@ import sys
 try:
     import yaml
 except ImportError:
-    sys.exit("Missing dependency: pip install pyyaml")
+    print("Missing dependency: pip install pyyaml", file=sys.stderr)
+    sys.exit(3)
 
 try:
     from galaxy.tool_util_models import UserToolSource, format_validation_errors
     from galaxy.tool_util.lint import lint_user_tool_source
 except ImportError:
-    sys.exit("Missing dependency: pip install galaxy-tool-util")
+    print("Missing dependency: pip install galaxy-tool-util", file=sys.stderr)
+    sys.exit(3)
 
 from pydantic import ValidationError
 
@@ -40,7 +42,15 @@ def main(argv):
         sys.exit(__doc__)
 
     source = argv[1]
-    text = sys.stdin.read() if source == "-" else open(source).read()
+    try:
+        if source == "-":
+            text = sys.stdin.read()
+        else:
+            with open(source) as fh:
+                text = fh.read()
+    except OSError as exc:
+        print(f"Cannot read {source}: {exc}", file=sys.stderr)
+        return 3
     data = yaml.safe_load(text)
 
     try:

--- a/udt-authoring/scripts/validate.py
+++ b/udt-authoring/scripts/validate.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Validate and lint a Galaxy User-Defined Tool (UDT) offline.
+
+Runs the same checks Galaxy runs on the server -- the ``UserToolSource`` schema
+(structure + the four semantic validators) and ``lint_user_tool_source`` -- without
+needing a live Galaxy. Use it as a fast pre-submit gate before create_user_tool.
+
+Requirements:
+    pip install galaxy-tool-util pyyaml
+
+Usage:
+    python validate.py my-tool.yml
+    python validate.py -            # read YAML/JSON from stdin
+
+Exit codes:
+    0  valid and lint-clean
+    1  schema validation failed
+    2  lint findings (server create would reject these)
+    3  missing dependency or unreadable input
+"""
+
+import sys
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("Missing dependency: pip install pyyaml")
+
+try:
+    from galaxy.tool_util_models import UserToolSource, format_validation_errors
+    from galaxy.tool_util.lint import lint_user_tool_source
+except ImportError:
+    sys.exit("Missing dependency: pip install galaxy-tool-util")
+
+from pydantic import ValidationError
+
+
+def main(argv):
+    if len(argv) != 2:
+        sys.exit(__doc__)
+
+    source = argv[1]
+    text = sys.stdin.read() if source == "-" else open(source).read()
+    data = yaml.safe_load(text)
+
+    try:
+        tool = UserToolSource.model_validate(data)
+    except ValidationError as exc:
+        print("Schema validation FAILED:")
+        for bullet in format_validation_errors(exc):
+            print(f"  - {bullet}")
+        return 1
+
+    findings = lint_user_tool_source(tool)
+    if findings:
+        print("Lint findings (server create would reject these):")
+        for bullet in findings:
+            print(f"  - {bullet}")
+        return 2
+
+    print(f"OK: '{tool.name}' is valid and lint-clean.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## What this is

A new `udt-authoring` skill that distills the knowledge baked into Galaxy's `custom_tool` agent into a standalone, fetchable skill, so external agents -- Loom in particular -- can author valid `GalaxyUserTool` YAML on their own instead of guessing at the format.

The motivation: Loom can already create and run UDTs through the Galaxy MCP, but nothing taught the agent the actual format, so it tended to fall back on classic XML/Cheetah habits. This skill is the missing reference.

## What's in it

- **SKILL.md** -- the mental model (container + `shell_command` + typed inputs/outputs, sandboxed `$(...)` templating, must run in a container), a minimal skeleton, the authoring loop, and a "choosing a container" section.
- **references/** -- the full `UserToolSource` schema and validators, the `$(...)` templating model (`$GALAXY_SLOTS`, escaping, heredoc scripts), and a common-mistakes checklist.
- **scripts/validate.py** -- runs the *same* schema + lint the server runs (`galaxy-tool-util`), so a definition can be checked offline before submitting.
- **examples/** -- seven complete, validated UDTs from a one-liner up to a real biocontainer tool and an inline `python:slim` script.
- Discovery wired into the README and AGENTS routing.

## How I tested it

- All seven examples validate clean; deliberately-broken definitions are rejected with the documented error codes.
- Checked against a real failed-then-fixed UDT from a Loom session (a plotting tool whose biocontainer tag didn't exist): both the failing and working definitions validate identically to how the live server treated them -- which drove the "lint-clean ≠ will run, verify the container" guidance.
- Ran a fresh agent with the skill on a new task (samtools sort) -- it avoided every mistake a no-skill baseline made.
- End-to-end round trip on a live Galaxy: `create_user_tool` → `run_user_tool` → job `ok` → correct output, then cleaned up.

## Follow-ups

- **`planemo lint` for UDTs.** The local check ships as `scripts/validate.py`, but planemo already depends on `galaxy-tool-util` (which has the schema + lint), so down the road this should migrate to `planemo lint <tool>.yml` -- the same checks through the standard Galaxy tool CLI instead of a bundled script.

Opening as a draft for a look before it goes in.
