### PR TITLE
Bring udt-authoring in line with the 26.1 custom-tool agent work

### DIFF
--- a/udt-authoring/SKILL.md
+++ b/udt-authoring/SKILL.md
@@ -3,7 +3,7 @@ name: udt-authoring
 description: "Use when authoring a Galaxy User-Defined Tool (UDT) -- a `class: GalaxyUserTool` YAML definition that wraps a container and command into a tool a non-admin user creates and runs (e.g. via Galaxy MCP create_user_tool / run_user_tool, or POST /api/unprivileged_tools). Not for classic XML/ToolShed tool wrappers."
 metadata:
   surfaces: [loom]
-version: 1.0.0
+version: 1.1.0
 tags: [galaxy, tools, udt, user-defined-tools, custom-tool]
 ---
 
@@ -51,7 +51,7 @@ If you find yourself writing `command:`, `$param`, `#for#`, `truevalue:`, or `${
 ```yaml
 class: GalaxyUserTool          # required, exactly this
 id: my-tool                    # lowercase, ^[a-z][a-z0-9_-]*$, 3-255 chars (recommended)
-version: "0.1.0"               # recommended
+version: "0.1.0"               # required -- schema validation rejects a versionless tool
 name: My Tool                  # required, min 5 chars
 description: One line shown in the tool menu
 container: quay.io/biocontainers/seqkit:2.8.2--h9ee0642_0   # required STRING, a real image
@@ -76,12 +76,12 @@ Templating syntax (`$(inputs.x)`, arrays, `$GALAXY_SLOTS`, escaping): **`referen
 ## Authoring Workflow
 
 1. **Understand the command.** What binary runs, what inputs it consumes, what files it produces.
-2. **Pick a real container** -- this is the #1 cause of runtime failure. Prefer a verified
-   biocontainer (`quay.io/biocontainers/<tool>:<tag>`), but **never guess the `--<hash>_<build>`
-   tag suffix** -- it is not predictable. Look up the real tag, or, when the tool needs only the
-   Python standard library, use an official `python:3.x-slim` image and write the logic inline.
-   **Do not invent an image or flag you cannot verify** -- ask instead. See "Choosing a container"
-   below. Lint will *not* catch a bad image; the job simply fails to pull it.
+2. **Pick a real container** -- this is the #1 cause of runtime failure. Resolve a verified image
+   with `recommend_biocontainer` (Galaxy MCP) or the `mulled-recommend` CLI rather than guessing;
+   **never invent the `--<hash>_<build>` tag suffix** -- it is not predictable. For stdlib-only
+   logic, use an official `python:3.x-slim` image and write the code inline. **Do not invent an
+   image or flag you cannot verify** -- ask instead. See "Choosing a Container" below. Lint will
+   *not* catch a bad image; the job simply fails to pull it.
 3. **Draft the definition** using `references/schema-reference.md`. Reference each input as
    `$(inputs.name.path)` (data) or `$(inputs.name)` (scalar). Write outputs to fixed filenames and
    claim them with `from_work_dir` / `discover_datasets`. Always include a `help` block (convention
@@ -99,15 +99,30 @@ that declared `quay.io/biocontainers/seaborn:0.13.2--pyhd8ed1ab_3` was accepted 
 `create_user_tool`, then the job died with `manifest unknown` -- that exact build tag did not exist
 on quay. Guard against it:
 
-- **Don't guess the biocontainers build suffix** (`--<hash>_<build>`). It is not derivable from the
-  version. Look up the real tag: browse `https://quay.io/repository/biocontainers/<tool>?tab=tags`
-  or query `https://quay.io/api/v1/repository/biocontainers/<tool>/tag/?onlyActiveTags=true`.
+- **Resolve a verified image instead of guessing one -- do this first.** If a
+  `recommend_biocontainer` tool is available (Galaxy MCP), call it with the conda packages your
+  command needs -- e.g. `["samtools=1.17", "bwa"]` -- and use the `image` it returns. It's resolved
+  and checked against quay.io rather than hallucinated, so it can't invent a nonexistent tag. A
+  single package yields a single-package image; several yield a mulled-v2 image. The returned
+  `match_quality` tells you whether the exact version matched (`exact_version`) or only the name did
+  (`name_only`, newest tag used), and `verified` confirms the tag is actually built. Only auto-apply
+  an `exact_version` result; if it comes back `name_only` and the exact version matters, review the
+  substituted tag before using it. From a terminal,
+  the same resolver is the **`mulled-recommend`** CLI in `galaxy-tool-util`:
+  `mulled-recommend samtools=1.17`, `mulled-recommend --json "bwa,samtools"`.
+- **If you must pick by hand, don't guess the biocontainers build suffix** (`--<hash>_<build>`). It
+  is not derivable from the version. Look up the real tag: browse
+  `https://quay.io/repository/biocontainers/<tool>?tab=tags` or query
+  `https://quay.io/api/v1/repository/biocontainers/<tool>/tag/?onlyActiveTags=true`.
 - **For a stdlib-only tool, skip biocontainers entirely.** Use an official base image like
   `python:3.11-slim` (or `busybox` for shell-only) and write the logic inline (see the heredoc
   pattern in `references/templating.md`). The seaborn failure above was fixed exactly this way:
   switch to `python:3.11-slim` and emit SVG with the standard library, no third-party image to get
-  wrong.
-- **Never invent an image, tag, or CLI flag you can't verify** -- ask the user rather than guessing.
+  wrong. (A bare language image ships no third-party libraries -- `python:3.13` cannot `import
+  pandas` -- so this is only for genuinely stdlib-only logic; otherwise resolve a package image
+  above.)
+- **Never invent an image, tag, or CLI flag you can't verify** -- resolve it (above) or ask the user
+  rather than guessing.
 
 ## Write a `help` block (convention)
 
@@ -142,8 +157,14 @@ Validation logic is pure Python in `galaxy-tool-util` -- the same code the serve
 check offline before submitting. Three tiers, weakest to strongest:
 
 1. **Local** (fast, offline, side-effect-free): `python scripts/validate.py my-tool.yml`. Needs
-   `pip install galaxy-tool-util`. Catches structural errors, the four semantic validators, and
+   `pip install 'galaxy-tool-util>=26.1'`. Catches structural errors, the four semantic validators, and
    lint warnings. Use this whenever a Python env is available (terminal, CI). See `scripts/`.
+   **Version-sensitive:** the installed galaxy-tool-util *is* the schema, and the 26.1 behaviors this
+   skill describes (data inputs rejecting `min`/`max`, a minimal `discover_datasets`,
+   `--check-container`) need galaxy-tool-util **26.1+** -- so install
+   `pip install 'galaxy-tool-util>=26.1'`. On an older install the same file validates against the
+   older schema, which is a different answer, not a wrong one: if your target server is older, that
+   *is* the schema you're writing against. Either way the server create (tier 3) is the final word.
 2. **`planemo lint`** -- not available yet (planemo does not lint UDTs as of this writing). It
    already depends on `galaxy-tool-util`, so teaching it to lint a `GalaxyUserTool` YAML would be a
    small addition, and it's the natural future home for tier 1. Down the road `scripts/validate.py`
@@ -154,13 +175,14 @@ check offline before submitting. Three tiers, weakest to strongest:
    role). This is the final word, and the practical gate for environments without Python (e.g.
    Loom): submit, then iterate on the returned errors.
 
-> **Lint-clean is necessary but not sufficient.** No check here -- not validate.py, not the server's
-> create lint -- verifies that the container image actually pulls or that the command succeeds.
-> Those only surface when the job runs. A nonexistent container tag (`manifest unknown` at run
-> time) is the most common real-world UDT failure, so verify the image (see "Choosing a Container")
-> before relying on a clean validation. It also can't see runtime JS-expression errors, shell
-> quoting, the server's role/config gates, or whether the command actually produces the declared
-> outputs -- only running the tool does.
+> **Lint-clean is necessary but not sufficient.** Neither validate.py nor the server's create lint
+> checks that the command actually succeeds. The one thing you *can* check ahead of time is the
+> container: a nonexistent tag (`manifest unknown` at run time) is the most common real-world UDT
+> failure, so resolve a verified image with `recommend_biocontainer` / `mulled-recommend` (see
+> "Choosing a Container") -- or run `validate.py --check-container` to test the tag you already have.
+> Beyond that, validation can't see runtime JS-expression errors, shell quoting, the server's
+> role/config gates, or whether the command produces the declared outputs -- only running the tool
+> does.
 
 ## Iterating & Cleanup
 
@@ -195,7 +217,7 @@ inside the container.
 | Capture many outputs | declare output `type: collection` with `discover_datasets` |
 | Run a non-trivial inline script | `python <<'PY'` ... `PY` heredoc; reference inputs as `$(inputs.x)` inside (see `references/templating.md`) |
 
-See `examples/` for seven complete, validated UDTs spanning these patterns.
+See `examples/` for eight complete, validated UDTs spanning these patterns.
 
 ## Troubleshooting
 
@@ -206,7 +228,7 @@ See `examples/` for seven complete, validated UDTs spanning these patterns.
 | `dynamic_tool.blank_container` | `container` empty / missing | Set a real container image string |
 | `string_pattern_mismatch` on `id` | Uppercase, leading digit, spaces | Use `^[a-z][a-z0-9_-]*$` |
 | extra-field rejection | XML-ism like `truevalue`, `command`, `${on_string}` | Remove it -- schema is `extra="forbid"` |
-| `manifest unknown` / `Unable to find image` at **run** time | Container tag doesn't exist on the registry | Use a real, verified tag (or `python:3.x-slim` for stdlib tools) -- lint can't catch this |
+| `manifest unknown` / `Unable to find image` at **run** time | Container tag doesn't exist on the registry | Resolve a verified image with `recommend_biocontainer` / `mulled-recommend` (or `python:3.x-slim` for stdlib tools) -- lint can't catch this |
 | HTTP 403 "not allowed to run unprivileged" | The admin's job routing (TPV) rejects `tool_type_user_defined` by default | Not fixable client-side -- the admin must add a destination/routing rule for user-defined tools |
 | `help` rejected at create | `help` sent as a bare string | Use the object form: `help: {format, content}` |
 
@@ -218,6 +240,6 @@ Full list with the why behind each: `references/common-mistakes.md`.
 - `references/templating.md` -- the `$(...)` ECMAScript model, arrays, `$GALAXY_SLOTS`, escaping
 - `references/common-mistakes.md` -- pre-submit self-review checklist
 - `scripts/validate.py` -- offline validate + lint via `galaxy-tool-util`
-- `examples/` -- seven complete UDTs, simple to complex (incl. an inline-script `python:slim` tool)
+- `examples/` -- eight complete UDTs, simple to complex (incl. inline-script and configfile-script `python:slim` tools)
 - Galaxy docs: [User-Defined Tools](https://docs.galaxyproject.org/en/master/admin/user_defined_tools.html)
 - For classic XML tools instead: the `tool-dev` skill.

--- a/udt-authoring/examples/08-configfile-script.yml
+++ b/udt-authoring/examples/08-configfile-script.yml
@@ -1,0 +1,74 @@
+# Real-world pattern: run a longer script by NAME, and pass an untrusted `text`
+# parameter SAFELY. Two things to notice:
+#   1. The script is materialized by a `configfiles` entry whose `filename` is
+#      exactly what `shell_command` runs -- the critical rule from
+#      references/templating.md. (`python summarize.py` with no configfile that
+#      creates summarize.py would be broken -- the file wouldn't exist at run time.)
+#   2. The `column` value is a free-text input, so it is NOT interpolated into
+#      Python source (a quote or newline could break or inject into the code).
+#      Instead it's written to a JSON configfile via `JSON.stringify(...)` -- which
+#      safely encodes any string -- and the script reads it back as data.
+class: GalaxyUserTool
+id: column-summary-configfile
+version: "0.1.0"
+name: Summarize a numeric column (configfile)
+description: Report count, mean, min, and max of one numeric column in a tabular file
+container: python:3.11-slim
+configfiles:
+  - filename: params.json
+    content: |
+      {"table": $(JSON.stringify(inputs.table.path)), "column": $(JSON.stringify(inputs.column))}
+  - filename: summarize.py
+    content: |
+      import csv
+      import json
+
+      with open("params.json") as fh:
+          params = json.load(fh)
+      path = params["table"]
+      column = params["column"]
+
+      values = []
+      with open(path, newline="") as fh:
+          for row in csv.DictReader(fh, delimiter="\t"):
+              cell = row.get(column, "")
+              try:
+                  values.append(float(cell))
+              except (TypeError, ValueError):
+                  continue  # skip empty and non-numeric cells
+      if not values:
+          raise SystemExit(f"No numeric values found in column {column!r}")
+      n = len(values)
+      with open("summary.txt", "w") as out:
+          out.write(f"column\t{column}\n")
+          out.write(f"count\t{n}\n")
+          out.write(f"mean\t{sum(values) / n}\n")
+          out.write(f"min\t{min(values)}\n")
+          out.write(f"max\t{max(values)}\n")
+shell_command: python summarize.py
+inputs:
+  - name: table
+    type: data
+    format: tabular
+    label: Tabular input
+  - name: column
+    type: text
+    label: Column name to summarize
+    help: Must match a column header in the tabular file.
+outputs:
+  - name: summary
+    type: data
+    format: txt
+    from_work_dir: summary.txt
+    label: Column summary
+help:
+  format: markdown
+  content: |
+    Reports count, mean, min, and max of one numeric column in a tabular file.
+
+    **Inputs** -- `table`: a tabular file; `column`: the column header to summarize.
+    **Outputs** -- `summary`: a small text report.
+
+    The script is delivered as a configfile named `summarize.py` and run by name;
+    the column name is passed via a JSON configfile (not inlined into the code).
+    The column must match a header in the file; empty and non-numeric cells are skipped.

--- a/udt-authoring/references/common-mistakes.md
+++ b/udt-authoring/references/common-mistakes.md
@@ -9,7 +9,10 @@ plus a few schema-specific traps. Run through this before submitting.
 - [ ] Parameters use **`$(inputs.x)`** / **`$(inputs.x.path)`**, not Cheetah `$x` or `#for#`.
 - [ ] `container` is a **plain string** of a **real** image (verified biocontainer when possible).
 - [ ] Every output has **`from_work_dir`** or **`discover_datasets`** (collections: `discover_datasets`).
+- [ ] Outputs are captured by file (`from_work_dir`/`discover_datasets`); there is **no** `$(outputs.X.path)`.
 - [ ] Every `$(inputs.X)` reference has a matching declared input named `X`.
+- [ ] If `shell_command` runs a script by name (`python script.py`), a `configfiles` entry creates that exact filename -- otherwise inline it with `python -c` / `Rscript -e`.
+- [ ] No `min`/`max` on a `data` input (it's already required; use `optional: true` to relax, `multiple: true` for a list).
 - [ ] `id` matches `^[a-z][a-z0-9_-]*$`; `name` is at least 5 characters.
 - [ ] No rejected fields: `truevalue`, `falsevalue`, `argument`, `parameter_type`, `${on_string}`, `${tool.name}`.
 - [ ] Booleans become flags via a ternary, not `truevalue`/`falsevalue`.
@@ -28,8 +31,11 @@ plus a few schema-specific traps. Run through this before submitting.
 | `'$(inputs.reads)'` for a data input | A data input is an object, not a path. | `'$(inputs.reads.path)'`. |
 | `container: {type: docker, image: ...}` | `container` is a plain string. | `container: quay.io/biocontainers/...`. |
 | Output written to `'$(inputs.out)'` / a templated output path | UDTs don't pass output paths in; the file is claimed afterward. | Write to a fixed filename, then `from_work_dir: that-file`. |
+| `$(outputs.name.path)` in the command | There is no `outputs` object in the template namespace -- only `inputs`. | Write to a fixed filename and claim it with `from_work_dir`/`discover_datasets`. |
+| `python script.py` with no `configfiles` entry named `script.py` | The file is never created in the working dir, so the command fails at runtime (lint won't catch it). | Add a `configfiles` entry whose `filename` is exactly `script.py`, or inline the code with `python -c`. |
 | Output with neither `from_work_dir` nor `discover_datasets` | `dynamic_tool.output_unclaimed`. | Add one of them. |
 | `$(inputs.foo)` but no input `foo` | `dynamic_tool.undeclared_input_ref`. | Declare `foo` or fix the typo. |
+| `min: 1` / `max: N` on a `data` input | Dropped from the schema in 26.1 (`extra="forbid"` rejects them); authors used `min: 1` to mean "required," but data inputs already are. | Remove them. Data inputs are required by default (`optional: true` to relax); use `multiple: true` to accept several. |
 | `truevalue: --x` / `falsevalue: ""` on a boolean | XML-only fields, rejected. | `value: false` + `$(inputs.x ? '--x' : '')` in the command. |
 | `${on_string}`, `${tool.name}` in labels | Cheetah macros; not supported. | Use a plain string label, or `format_source` to inherit. |
 | `id: My_Tool` / `id: 2pass` | Must be lowercase and start with a letter (`string_pattern_mismatch`). | `id: my-tool`, `id: two-pass`. |
@@ -47,6 +53,9 @@ schema/lint never check that the image exists. Real case: a plotting UDT declare
 `quay.io/biocontainers/seaborn:0.13.2--pyhd8ed1ab_3`, was accepted by `create_user_tool`, and the
 job died with `manifest unknown` because that exact build tag didn't exist on quay.
 
+- **Resolve a verified image instead of guessing.** Call `recommend_biocontainer` (Galaxy MCP) with
+  the conda packages (`["samtools=1.17", "bwa"]`) and use the `image` it returns, or run
+  `mulled-recommend samtools=1.17` in a terminal -- both check quay.io rather than hallucinating.
 - **Never guess the biocontainers build suffix** (`--<hash>_<build>`) -- it isn't derivable from the
   version number. Look it up: browse `https://quay.io/repository/biocontainers/<tool>?tab=tags` or
   query `https://quay.io/api/v1/repository/biocontainers/<tool>/tag/?onlyActiveTags=true`.
@@ -54,7 +63,8 @@ job died with `manifest unknown` because that exact build tag didn't exist on qu
   write the logic inline -- there's no third-party tag to get wrong. The seaborn failure above was
   fixed precisely this way: switch to `python:3.11-slim` and emit SVG with the standard library.
 - **A clean `validate.py` does not mean the image pulls.** Lint validates the YAML, not the
-  registry. Verify the image separately, or let the server-create + first run confirm it.
+  registry. Verify the image separately -- `validate.py --check-container`, `recommend_biocontainer`,
+  or `mulled-recommend` -- or let the server-create + first run confirm it.
 
 ## Clarity pass (what a deterministic validator can't catch)
 

--- a/udt-authoring/references/schema-reference.md
+++ b/udt-authoring/references/schema-reference.md
@@ -4,6 +4,11 @@ The canonical schema for a UDT is the `UserToolSource` Pydantic model in
 `galaxy-tool-util` (`galaxy.tool_util_models`). It is `extra="forbid"`: **any unknown field is
 rejected at parse time.** Field names below are exact.
 
+When you submit via `create_user_tool` / `POST /api/unprivileged_tools`, the server validates this
+full `UserToolSource`, so everything here applies. (Galaxy's *in-app* authoring agent targets a
+slimmed view of the same model that drops the `tests` block to shrink its structured-output schema;
+`tests` is optional either way and usually skipped for a first version.)
+
 ## Top-level fields
 
 | Field | Required | Type | Notes |
@@ -13,7 +18,7 @@ rejected at parse time.** Field names below are exact.
 | `container` | **yes** | string | Container image, e.g. `quay.io/biocontainers/seqkit:2.8.2--h9ee0642_0`. A plain **string**, never a dict/list. Not blank. |
 | `shell_command` | **yes** | string | Command with `$(...)` expressions. The field is `shell_command`, not `command`. |
 | `id` | no (recommended) | string | Pattern `^[a-z][a-z0-9_-]*$`, length 3-255. Lowercase, starts with a letter; hyphens and underscores allowed. |
-| `version` | no (recommended) | string | e.g. `"0.1.0"`. Not blank/whitespace. Quote it so YAML doesn't read it as a number. |
+| `version` | **yes** | string | e.g. `"0.1.0"`. Required on 26.1+ -- a versionless tool fails schema validation with `version: Field required`. Not blank/whitespace; quote it so YAML doesn't read it as a number. |
 | `description` | no | string | Short line in the tool menu. |
 | `inputs` | no (default `[]`) | list | Input parameters (see below). |
 | `outputs` | no (default `[]`) | list | Output definitions (see below). |
@@ -38,7 +43,7 @@ Beyond those, each type supports:
 | `text` | `value`, `area` (bool), `validators` (`length`, `regex`, `empty_field`) |
 | `select` | `options` (static, non-empty), `multiple`, `validators` (`no_options`) |
 | `color` | `value` |
-| `data` | `format` (string or list of datatypes), `multiple`, `min`, `max` |
+| `data` | `format` (string or list of datatypes), `multiple` |
 | `data_collection` | `collection_type` (e.g. `list`, `paired`), `format` |
 
 `select` options are a list of `{label, value, selected}`:
@@ -58,6 +63,13 @@ and `whens`), `repeat` (has `parameters`, `min`, `max`), `section` (has `paramet
 `data_column`, `genomebuild`, `group_tag`, `baseurl`, `rules`, `directory`. **Rejected fields on
 any parameter:** `truevalue`, `falsevalue`, `argument`, `is_dynamic`, `hidden`, `parameter_type`.
 
+**`min`/`max` on a `data` input are rejected** (dropped from the authoring schema in Galaxy 26.1).
+They only ever meant the min/max *number of selected datasets* for a `multiple` input, and the
+runtime rejects them on a single one. Authors reached for `min: 1` to mean "required" -- but a
+`data` input is already required (add `optional: true` to make it *not* required). Use `multiple:
+true` to accept a list; never add `min`/`max` to a data input. (`min`/`max` stay valid on
+`integer`/`float`, where they bound the numeric value.)
+
 ## Output types
 
 Every output has `name` and `type`. **A dataset output must declare `from_work_dir` OR
@@ -76,10 +88,9 @@ Every output has `name` and `type`. **A dataset output must declare `from_work_d
 | `discover_datasets` | Alternative to `from_work_dir` for pattern-matched files. |
 
 **Collection output** (`type: collection`): `collection_type` (`list`, `paired`, ...) plus
-`discover_datasets` (required). Discovery is either a `pattern` or `tool_provided_metadata`. The
-`UserToolSource` model does **not** default the discovery fields, so a bare `[{pattern: ...}]` fails
-validation -- a pattern entry needs all of `discover_via`, `pattern`, `directory`, `format`,
-`visible`, `recurse`, `match_relative_path`, `assign_primary_output`, `sort_key`, `sort_comp`:
+`discover_datasets` (required). Discovery is either a `pattern` or `tool_provided_metadata`. On
+Galaxy 26.1+ every discovery field except the pattern has a sensible default, so a minimal entry
+validates -- you only supply `pattern`:
 
 ```yaml
 outputs:
@@ -87,21 +98,28 @@ outputs:
     type: collection
     collection_type: list
     discover_datasets:
-      - discover_via: pattern
-        pattern: 'part_(?P<designation>.+)\.txt'   # named groups: designation, ext, dbkey
-        directory: outdir
-        format: txt
-        visible: false
-        recurse: false
-        match_relative_path: false
-        assign_primary_output: false
-        sort_key: filename        # filename | name | designation | dbkey
-        sort_comp: lexical        # lexical | numeric
+      - pattern: 'part_(?P<designation>.+)\.txt'   # named groups: designation, ext, dbkey
 ```
 
-**Only `data` and `collection` outputs are supported.** The scalar output types present in the
-underlying model (`ToolOutputText`/`Integer`/`Float`/`Boolean`) are rejected by the UDT YAML parser
--- don't use them.
+Add a field only to override its default. The ones you'll actually reach for: `directory` (search
+a subdir instead of the job root), `format`, `visible`, `recurse`, `sort_key` (`filename` | `name` |
+`designation` | `dbkey`), `sort_comp` (`lexical` | `numeric`). That's the common subset, not the
+full list -- `discover_via`, `match_relative_path`, `assign_primary_output` and `sort_reverse` are
+also accepted; consult the model for the rest. The descriptor is `extra="forbid"`, so a mistyped key
+(`patern`) or an XML-only one (`sort_by`, `dbkey`) is rejected, not silently ignored.
+
+> **Server-version note.** The minimal one-field form needs Galaxy 26.1+; older servers required
+> every field spelled out. To stay compatible with an older Galaxy, write the fully-specified form
+> -- `discover_via: pattern` plus `directory`, `format`, `visible`, `recurse`,
+> `match_relative_path`, `assign_primary_output`, `sort_key`, `sort_comp` alongside `pattern` --
+> which still validates everywhere.
+
+**Only `data` and `collection` outputs are usable.** They capture files into the history -- write
+your result to a file and claim it. The scalar output types (`text`/`integer`/`float`/`boolean`) do
+exist in the authoring model, and on 26.1 a named one validates without `hidden`, so `validate.py`
+will pass a tool that declares one. It still won't *run*: the YAML tool parser accepts only `data`
+and `collection` and raises `Unknown output_type [integer] encountered` on anything else. A clean
+validation is not a green light here -- use `data` or `collection`.
 
 ## Requirements
 

--- a/udt-authoring/references/templating.md
+++ b/udt-authoring/references/templating.md
@@ -108,12 +108,26 @@ shell_command: |
 runtime, but they aren't covered by the official UDT docs -- confirm on your target server before
 relying on them.
 
-## Embedding a script (heredoc)
+## Running a script
 
-For logic beyond a one-liner, embed a script with a shell heredoc and reference inputs with
-`$(inputs.x)` inside it. Galaxy expands the `$(...)` expressions **before** the shell runs, so a
-quoted heredoc (`<<'PY'`) is correct -- it stops the shell from re-expanding things, while Galaxy
-has already substituted the inputs:
+You have three ways to run script logic. Pick one and complete it fully -- a `shell_command` that
+*names* a script file with nothing that creates it is the most common broken-but-lint-clean tool
+(the file won't exist at runtime, and lint can't catch it).
+
+**1. One-liner: inline it with `python -c` / `Rscript -e`.** Self-contained, nothing else to
+declare; reference inputs directly:
+
+```yaml
+container: quay.io/biocontainers/pandas:2.1.1
+shell_command: >-
+  python -c "import pandas as pd; d = pd.read_csv('$(inputs.table.path)', sep='\t');
+  d.describe().to_csv('summary.tsv', sep='\t')"
+```
+
+**2. A few lines: embed it with a quoted heredoc.** Reference inputs with `$(inputs.x)` inside.
+Galaxy expands the `$(...)` expressions **before** the shell runs, so a quoted heredoc (`<<'PY'`)
+is correct -- it stops the shell from re-expanding things, while Galaxy has already substituted the
+inputs:
 
 ```yaml
 container: python:3.11-slim          # an inline Python script needs only a base Python image
@@ -155,3 +169,28 @@ shell_command: |
 
 Input references inside a configfile count toward `dynamic_tool.undeclared_input_ref`, same as in
 `shell_command`.
+
+**3. Longer script: put it in a `configfiles` entry and run that file by name.** The file is
+materialized in the working directory at `filename`, so `shell_command` runs it by that name:
+
+```yaml
+configfiles:
+  - filename: script.py
+    content: |
+      import pandas as pd
+      df = pd.read_csv("$(inputs.table.path)", sep="\t")
+      df.describe().to_csv("summary.tsv", sep="\t")
+shell_command: python script.py
+```
+
+> **CRITICAL:** if `shell_command` runs a script by name (`python script.py`), you **must** include
+> a `configfiles` entry whose `filename` is exactly that name. `python script.py` with no configfile
+> that creates it is broken -- the file won't exist at runtime, and neither lint nor `create_user_tool`
+> will catch it. If you don't want a configfile, inline the script with `python -c` (option 1) instead.
+
+**Don't interpolate a free-text input straight into script *source*.** Inlining `$(inputs.name)`
+into Python/R code (heredoc or configfile) has the same problem as inlining it into `shell_command`:
+a quote, backslash, or newline in a `text`/`select` value breaks the script or injects code. Data
+`.path` values are Galaxy-generated and safe to inline; user-controlled text is not. For text, write
+it to a JSON configfile with `$(JSON.stringify(inputs.name))` (which safely encodes any string) and
+read it back as data in the script -- see `examples/08-configfile-script.yml`.

--- a/udt-authoring/scripts/validate.py
+++ b/udt-authoring/scripts/validate.py
@@ -6,16 +6,17 @@ Runs the same checks Galaxy runs on the server -- the ``UserToolSource`` schema
 needing a live Galaxy. Use it as a fast pre-submit gate before create_user_tool.
 
 Requirements:
-    pip install galaxy-tool-util pyyaml
+    pip install 'galaxy-tool-util>=26.1' pyyaml   # 26.1+ for --check-container
 
 Usage:
     python validate.py my-tool.yml
-    python validate.py -            # read YAML/JSON from stdin
+    python validate.py -                      # read YAML/JSON from stdin
+    python validate.py my-tool.yml --check-container   # also verify the container tag on quay.io
 
 Exit codes:
-    0  valid and lint-clean
+    0  valid and lint-clean (and, with --check-container, the image is built or unverifiable)
     1  schema validation failed
-    2  lint findings (server create would reject these)
+    2  lint findings, or --check-container found the image is positively absent
     3  missing dependency or unreadable input
 """
 
@@ -31,17 +32,47 @@ try:
     from galaxy.tool_util_models import UserToolSource, format_validation_errors
     from galaxy.tool_util.lint import lint_user_tool_source
 except ImportError:
-    print("Missing dependency: pip install galaxy-tool-util", file=sys.stderr)
+    print("Missing dependency: pip install 'galaxy-tool-util>=26.1'", file=sys.stderr)
     sys.exit(3)
 
 from pydantic import ValidationError
 
 
+def _check_container(image):
+    """Check whether ``image`` is actually built on quay.io. Returns an exit code.
+
+    Uses the mulled-recommend helper added in Galaxy 26.1; if the installed
+    galaxy-tool-util predates it, say so and don't fail the run.
+    """
+    try:
+        from galaxy.tool_util.deps.mulled.recommend import biocontainer_tag_built
+    except ImportError:
+        print(
+            "--check-container needs a galaxy-tool-util with mulled-recommend (Galaxy 26.1+); "
+            "skipping the image check.",
+            file=sys.stderr,
+        )
+        return 0
+
+    built = biocontainer_tag_built(image)
+    if built is True:
+        print(f"Container OK: {image} is built on quay.io.")
+        return 0
+    if built is False:
+        print(f"Container MISSING: {image} is not built on quay.io -- the job would fail with 'manifest unknown'.")
+        return 2
+    print(f"Container UNVERIFIED: could not check {image} (non-biocontainer reference or transient error).")
+    return 0
+
+
 def main(argv):
-    if len(argv) != 2:
+    args = argv[1:]
+    check_container = "--check-container" in args
+    args = [a for a in args if a != "--check-container"]
+    if len(args) != 1:
         sys.exit(__doc__)
 
-    source = argv[1]
+    source = args[0]
     try:
         if source == "-":
             text = sys.stdin.read()
@@ -69,6 +100,8 @@ def main(argv):
         return 2
 
     print(f"OK: '{tool.name}' is valid and lint-clean.")
+    if check_container:
+        return _check_container(tool.container)
     return 0
 
 


### PR DESCRIPTION
Galaxy 26.1 reworked how the in-app custom-tool agent authors UDTs (galaxyproject/galaxy#22968) and then added verified container resolution (galaxyproject/galaxy#22981). The `udt-authoring` skill was distilled from the older prompt, so parts of it had gone stale. This brings it back in line so Loom and other external agents get the same guidance Galaxy's own agent now gets.

### Schema changes

- `min`/`max` on a `data` input are rejected now. Authors kept reaching for `min: 1` to mean "required", which a data input already is -- the reference explains that and points at `optional: true` / `multiple: true` instead.
- A `discover_datasets` entry validates from just a `pattern` on 26.1+. Older servers still want the full field list, so there's a server-version note for anyone targeting one.
- `version` is now plainly required. The old text said lint rejects a versionless tool; that's not right -- it fails schema validation with `version: Field required` before lint ever runs.
- Stopped hedging about scalar outputs. They *do* validate against the authoring model on 26.1, but the YAML parser accepts only `data` and `collection` and raises `Unknown output_type` on anything else. A clean `validate.py` is not a green light there, and the skill now says so.

### Authoring

Spelled out the three ways to run a script -- inline `python -c`, a quoted heredoc, or a configfile whose `filename` matches what `shell_command` runs -- and called out the run-a-script-with-no-configfile trap the agent now guards against. That one is broken-but-lint-clean, which makes it worth a CRITICAL callout. Also noted that `$(outputs.X.path)` isn't a real thing, and added a warning about interpolating free-text inputs into script *source* rather than passing them as data.

New `examples/08-configfile-script.yml` demonstrates both: a script delivered by configfile and run by name, with the untrusted `text` parameter passed through a JSON configfile via `JSON.stringify` instead of being inlined into Python.

### Containers

This is the bigger addition. The container section now leads with resolving a verified image -- `recommend_biocontainer` if a Galaxy MCP server offers it, or the `mulled-recommend` CLI -- instead of guessing a build suffix that isn't derivable from the version. It also explains `match_quality`, so `exact_version` is auto-appliable and `name_only` gets reviewed first. Hand-picking is still documented as the fallback.

`scripts/validate.py` grows `--check-container`, which runs `biocontainer_tag_built` over the declared image. Tri-state: built, positively absent (exit 2 -- this is the `manifest unknown` case), or unverifiable.

`galaxy-tool-util` 26.1 is on PyPI now, so the tier-1 instructions just pin `>=26.1` rather than warning you off it.

### Verification

Everything above was checked against a real `galaxy-tool-util` 26.1.1 from PyPI rather than against the release notes. All eight examples validate clean. The `min: 1` rejection, the minimal `discover_datasets`, the `version: Field required` failure, and the scalar-output behavior were each reproduced directly. `--check-container` was exercised across all three states, including against the real hallucinated `seaborn:0.13.2--pyhd8ed1ab_3` tag from the original bug, which correctly comes back absent.

Skill bumped to 1.1.0.

Companion PRs: galaxyproject/galaxy-mcp adds the `recommend_biocontainer` tool this skill points at, and galaxyproject/loom adds eval scenarios covering the container and typed-input dimensions.
